### PR TITLE
[dashboard] delete mui deps (unused)

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -14,10 +14,6 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
-    "@mui/icons-material": "^5.10.9",
-    "@mui/material": "^5.10.13",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
@@ -25,7 +21,6 @@
     "clsx": "^1.2.1",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.4",
-    "framer-motion": "^7.6.5",
     "next": "13.0.4",
     "normalize.css": "^8.0.1",
     "react": "18.2.0",


### PR DESCRIPTION
We don't use any of these.

### Test
The app still builds.
<img width="603" alt="image" src="https://user-images.githubusercontent.com/3942264/206826350-67948f7d-bc64-40b0-9ac8-89c62cf681d9.png">
