### PR TITLE
[dashboard] Fix safari input focus border radius and css refactoring

### DIFF
--- a/apps/dashboard/components/AppShell/AppShell.css.ts
+++ b/apps/dashboard/components/AppShell/AppShell.css.ts
@@ -1,4 +1,4 @@
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {font} from '@/volto/typography.css';
 import {style} from '@vanilla-extract/css';
 

--- a/apps/dashboard/components/AppShell/NavLink.css.ts
+++ b/apps/dashboard/components/AppShell/NavLink.css.ts
@@ -1,4 +1,4 @@
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {font} from '@/volto/typography.css';

--- a/apps/dashboard/components/NewProperty/DetailsForm/DetailsForm.css.ts
+++ b/apps/dashboard/components/NewProperty/DetailsForm/DetailsForm.css.ts
@@ -1,4 +1,4 @@
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {style, styleVariants} from '@vanilla-extract/css';

--- a/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/UnitEntry.css.ts
+++ b/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/UnitEntry.css.ts
@@ -1,4 +1,4 @@
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {font} from '@/volto/typography.css';
@@ -36,7 +36,7 @@ export const ActionButton = style({
   userSelect: 'none',
 
   ':hover': {
-    backgroundColor: color.primaryPallete[95],
+    backgroundColor: color.primary[95],
     color: color.text.$,
   },
 });

--- a/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.css.ts
+++ b/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.css.ts
@@ -1,11 +1,10 @@
 import * as border from '@/volto/border.css';
+import {boxShadow} from '@/volto/boxShadow.css';
 import * as color from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {font} from '@/volto/typography.css';
 import {style, styleVariants} from '@vanilla-extract/css';
-
-export const PropertyTypeSelector = style({});
 
 export const Label = style({
   fontWeight: font.weight.semibold,
@@ -23,18 +22,20 @@ export const Option = style({
   cursor: 'pointer',
   flexBasis: '50%',
   maxWidth: '25rem',
-  outline: `${border.width[2]} solid transparent`,
-  outlineOffset: `-${border.width[1]}`,
+  outline: 'none',
   padding: unit(4),
 });
 
 export const OptionState = styleVariants({
   selected: {
-    borderColor: 'transparent',
-    outlineColor: color.primaryPallete[35],
+    borderColor: color.primaryPallete[35],
+    boxShadow: boxShadow.asBorder(1, color.primaryPallete[35]),
   },
   focusVisible: {
-    boxShadow: `0 0 0 ${border.width[4]} ${color.primaryPallete[90]}`,
+    boxShadow: [
+      boxShadow.asBorder(1, color.primaryPallete[35]),
+      boxShadow.asBorder(4, color.primaryPallete[90]),
+    ].join(','),
   },
 });
 

--- a/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.css.ts
+++ b/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.css.ts
@@ -1,6 +1,6 @@
 import {border} from '@/volto/border.css';
 import {boxShadow} from '@/volto/boxShadow.css';
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {font} from '@/volto/typography.css';
@@ -28,13 +28,13 @@ export const Option = style({
 
 export const OptionState = styleVariants({
   selected: {
-    borderColor: color.primaryPallete[35],
-    boxShadow: boxShadow.asBorder(1, color.primaryPallete[35]),
+    borderColor: color.primary[35],
+    boxShadow: boxShadow.asBorder(1, color.primary[35]),
   },
   focusVisible: {
     boxShadow: [
-      boxShadow.asBorder(1, color.primaryPallete[35]),
-      boxShadow.asBorder(4, color.primaryPallete[90]),
+      boxShadow.asBorder(1, color.primary[35]),
+      boxShadow.asBorder(4, color.primary[90]),
     ].join(','),
   },
 });

--- a/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.css.ts
+++ b/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.css.ts
@@ -1,4 +1,4 @@
-import * as border from '@/volto/border.css';
+import {border} from '@/volto/border.css';
 import {boxShadow} from '@/volto/boxShadow.css';
 import * as color from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
@@ -17,7 +17,7 @@ export const Options = style({
 });
 
 export const Option = style({
-  border: `${border.width[1]} solid ${color.neutral[90]}`,
+  border: border.solid(1, color.neutral[90]),
   borderRadius: vars.border.radius,
   cursor: 'pointer',
   flexBasis: '50%',

--- a/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
@@ -16,7 +16,7 @@ export function PropertyTypeSelector({state}: PropertyTypeSelectorProps) {
   });
 
   return (
-    <div {...radioGroupProps} className={s.PropertyTypeSelector}>
+    <div {...radioGroupProps}>
       <h3 {...labelProps} className={s.Label}>
         Property type
       </h3>
@@ -25,14 +25,14 @@ export function PropertyTypeSelector({state}: PropertyTypeSelectorProps) {
           {...radioProps}
           value="single-family"
           label="Single-family property"
-          description="A property with one renter associates with one address such as a house."
+          description="A property with one renter associates with one address such as a house or a townhouse."
           state={state}
         />
         <PropertyTypeOption
           {...radioProps}
           value="multi-family"
           label="Multi-family property"
-          description="A building with multiple rental units such as an apartment or a condo."
+          description="A building with multiple rental units such as a duplex, an apartment, or a condo."
           state={state}
         />
       </div>

--- a/apps/dashboard/components/PropertySummary/PropertySummary.css.ts
+++ b/apps/dashboard/components/PropertySummary/PropertySummary.css.ts
@@ -1,4 +1,4 @@
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {unit} from '@/volto/spacing.css';
 import {font} from '@/volto/typography.css';
 import {style} from '@vanilla-extract/css';
@@ -28,7 +28,7 @@ export const Body = style({
 });
 
 export const Title = style({
-  color: color.primaryPallete[50],
+  color: color.primary[50],
   // fontSize: '1rem',
   fontWeight: font.weight.medium,
   transition: 'color 240ms',

--- a/apps/dashboard/volto/Button/Button.css.ts
+++ b/apps/dashboard/volto/Button/Button.css.ts
@@ -1,5 +1,5 @@
 import {border} from '@/volto/border.css';
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {font} from '@/volto/typography.css';
@@ -33,34 +33,34 @@ export const variant = styleVariants<{
   [K in ButtonVariant]: ComplexStyleRule;
 }>({
   contained: {
-    backgroundColor: color.primaryPallete[35],
+    backgroundColor: color.primary[35],
     color: 'white',
     ':hover': {
-      backgroundColor: color.primaryPallete[30],
+      backgroundColor: color.primary[30],
     },
     ':active': {
-      backgroundColor: color.primaryPallete[25],
+      backgroundColor: color.primary[25],
     },
   },
   outlined: {
-    border: `${border.width[1]} solid ${color.primaryPallete[35]}`,
+    border: `${border.width[1]} solid ${color.primary[35]}`,
     backgroundColor: color.background.transparent,
-    color: color.primaryPallete[35],
+    color: color.primary[35],
     ':hover': {
-      backgroundColor: color.primaryPallete[95],
+      backgroundColor: color.primary[95],
     },
     ':active': {
-      backgroundColor: color.primaryPallete[90],
+      backgroundColor: color.primary[90],
     },
   },
   text: {
     backgroundColor: color.background.transparent,
-    color: color.primaryPallete[35],
+    color: color.primary[35],
     ':hover': {
-      backgroundColor: color.primaryPallete[95],
+      backgroundColor: color.primary[95],
     },
     ':active': {
-      backgroundColor: color.primaryPallete[90],
+      backgroundColor: color.primary[90],
     },
   },
 });

--- a/apps/dashboard/volto/Button/Button.css.ts
+++ b/apps/dashboard/volto/Button/Button.css.ts
@@ -1,4 +1,4 @@
-import * as border from '@/volto/border.css';
+import {border} from '@/volto/border.css';
 import * as color from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';

--- a/apps/dashboard/volto/Card.css.ts
+++ b/apps/dashboard/volto/Card.css.ts
@@ -1,4 +1,4 @@
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {style} from '@vanilla-extract/css';
 

--- a/apps/dashboard/volto/Radio/Radio.css.ts
+++ b/apps/dashboard/volto/Radio/Radio.css.ts
@@ -1,5 +1,5 @@
 import {border} from '@/volto/border.css';
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {style} from '@vanilla-extract/css';
 
 export const Radio = style({
@@ -25,12 +25,12 @@ export const Radio = style({
   },
 
   ':checked': {
-    borderColor: color.primaryPallete[35],
+    borderColor: color.primary[35],
   },
 
   selectors: {
     '&:checked::before': {
-      backgroundColor: color.primaryPallete[35],
+      backgroundColor: color.primary[35],
     },
   },
 });

--- a/apps/dashboard/volto/Radio/Radio.css.ts
+++ b/apps/dashboard/volto/Radio/Radio.css.ts
@@ -1,4 +1,4 @@
-import * as border from '@/volto/border.css';
+import {border} from '@/volto/border.css';
 import * as color from '@/volto/color.css';
 import {style} from '@vanilla-extract/css';
 
@@ -10,7 +10,7 @@ export const Radio = style({
   height: '1em',
   padding: '0.2em',
   borderRadius: '50%',
-  border: `${border.width[1]} solid ${color.neutral[70]}`,
+  border: border.solid(1, color.neutral[70]),
 
   ':focus': {
     outline: 'none',

--- a/apps/dashboard/volto/Select.css.ts
+++ b/apps/dashboard/volto/Select.css.ts
@@ -1,4 +1,5 @@
 import * as border from '@/volto/border.css';
+import {boxShadow} from '@/volto/boxShadow.css';
 import * as color from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
@@ -15,13 +16,11 @@ export const Label = style({
 });
 
 const inputFocus = style({
-  outline: `${border.width[2]} solid transparent`,
-  outlineOffset: `-${border.width[1]}`,
+  outline: 'none',
 
-  ':focus': {
-    borderRadius: vars.border.radius,
-    borderColor: 'transparent',
-    outlineColor: color.primaryPallete[50],
+  ':focus-visible': {
+    borderColor: color.primaryPallete[50],
+    boxShadow: boxShadow.asBorder(1, color.primaryPallete[50]),
   },
 });
 

--- a/apps/dashboard/volto/Select.css.ts
+++ b/apps/dashboard/volto/Select.css.ts
@@ -1,4 +1,4 @@
-import * as border from '@/volto/border.css';
+import {border} from '@/volto/border.css';
 import {boxShadow} from '@/volto/boxShadow.css';
 import * as color from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
@@ -32,7 +32,7 @@ export const Input = style([
   {
     appearance: 'none', // remove user agent caret
     backgroundColor: 'transparent', // reset for Firefox
-    border: `${border.width[1]} solid ${color.neutral[90]}`,
+    border: border.solid(1, color.neutral[90]),
     borderRadius: vars.border.radius,
     lineHeight: 1,
     minHeight: vars.size[36],

--- a/apps/dashboard/volto/Select.css.ts
+++ b/apps/dashboard/volto/Select.css.ts
@@ -1,6 +1,6 @@
 import {border} from '@/volto/border.css';
 import {boxShadow} from '@/volto/boxShadow.css';
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {style} from '@vanilla-extract/css';
@@ -19,8 +19,8 @@ const inputFocus = style({
   outline: 'none',
 
   ':focus-visible': {
-    borderColor: color.primaryPallete[50],
-    boxShadow: boxShadow.asBorder(1, color.primaryPallete[50]),
+    borderColor: color.primary[50],
+    boxShadow: boxShadow.asBorder(1, color.primary[50]),
   },
 });
 

--- a/apps/dashboard/volto/TextField.css.ts
+++ b/apps/dashboard/volto/TextField.css.ts
@@ -1,4 +1,5 @@
 import * as border from '@/volto/border.css';
+import {boxShadow} from '@/volto/boxShadow.css';
 import * as color from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
@@ -15,13 +16,11 @@ export const Label = style({
 });
 
 const inputFocus = style({
-  outline: `${border.width[2]} solid transparent`,
-  outlineOffset: `-${border.width[1]}`,
+  outline: 'none',
 
-  ':focus': {
-    borderRadius: vars.border.radius,
-    borderColor: 'transparent',
-    outlineColor: color.primaryPallete[50],
+  ':focus-visible': {
+    borderColor: color.primaryPallete[50],
+    boxShadow: boxShadow.asBorder(1, color.primaryPallete[50]),
   },
 });
 

--- a/apps/dashboard/volto/TextField.css.ts
+++ b/apps/dashboard/volto/TextField.css.ts
@@ -1,6 +1,6 @@
 import {border} from '@/volto/border.css';
 import {boxShadow} from '@/volto/boxShadow.css';
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {style} from '@vanilla-extract/css';
@@ -19,8 +19,8 @@ const inputFocus = style({
   outline: 'none',
 
   ':focus-visible': {
-    borderColor: color.primaryPallete[50],
-    boxShadow: boxShadow.asBorder(1, color.primaryPallete[50]),
+    borderColor: color.primary[50],
+    boxShadow: boxShadow.asBorder(1, color.primary[50]),
   },
 });
 

--- a/apps/dashboard/volto/TextField.css.ts
+++ b/apps/dashboard/volto/TextField.css.ts
@@ -1,4 +1,4 @@
-import * as border from '@/volto/border.css';
+import {border} from '@/volto/border.css';
 import {boxShadow} from '@/volto/boxShadow.css';
 import * as color from '@/volto/color.css';
 import {vars} from '@/volto/root.css';
@@ -26,7 +26,7 @@ const inputFocus = style({
 
 export const Input = style([
   {
-    border: `${border.width[1]} solid ${color.neutral[90]}`,
+    border: border.solid(1, color.neutral[90]),
     borderRadius: vars.border.radius,
     lineHeight: 1,
     minHeight: vars.size[36],

--- a/apps/dashboard/volto/border.css.ts
+++ b/apps/dashboard/volto/border.css.ts
@@ -1,7 +1,23 @@
-export const width = {
+const borderWidth = {
   1: '0.0625rem',
   2: '0.125rem',
   3: '0.1875rem',
   4: '0.25rem',
   5: '0.3125rem',
 };
+
+export type BorderWidthKey = keyof typeof borderWidth;
+
+export const border = {
+  solid,
+  width,
+};
+
+function solid(width: BorderWidthKey, color: string) {
+  const w = border.width(width);
+  return `${w} solid ${color}`;
+}
+
+function width(width: BorderWidthKey): string {
+  return borderWidth[width];
+}

--- a/apps/dashboard/volto/border.css.ts
+++ b/apps/dashboard/volto/border.css.ts
@@ -10,14 +10,10 @@ export type BorderWidthKey = keyof typeof borderWidth;
 
 export const border = {
   solid,
-  width,
+  width: borderWidth,
 };
 
 function solid(width: BorderWidthKey, color: string) {
-  const w = border.width(width);
+  const w = borderWidth[width];
   return `${w} solid ${color}`;
-}
-
-function width(width: BorderWidthKey): string {
-  return borderWidth[width];
 }

--- a/apps/dashboard/volto/boxShadow.css.ts
+++ b/apps/dashboard/volto/boxShadow.css.ts
@@ -1,0 +1,10 @@
+import * as border from './border.css';
+
+export const boxShadow = {
+  asBorder,
+};
+
+function asBorder(width: keyof typeof border.width, color: string): string {
+  const w = border.width[width];
+  return `0 0 0 ${w} ${color}`;
+}

--- a/apps/dashboard/volto/boxShadow.css.ts
+++ b/apps/dashboard/volto/boxShadow.css.ts
@@ -5,6 +5,6 @@ export const boxShadow = {
 };
 
 function asBorder(width: BorderWidthKey, color: string): string {
-  const w = border.width(width);
+  const w = border.width[width];
   return `0 0 0 ${w} ${color}`;
 }

--- a/apps/dashboard/volto/boxShadow.css.ts
+++ b/apps/dashboard/volto/boxShadow.css.ts
@@ -1,10 +1,10 @@
-import * as border from './border.css';
+import {border, BorderWidthKey} from './border.css';
 
 export const boxShadow = {
   asBorder,
 };
 
-function asBorder(width: keyof typeof border.width, color: string): string {
-  const w = border.width[width];
+function asBorder(width: BorderWidthKey, color: string): string {
+  const w = border.width(width);
   return `0 0 0 ${w} ${color}`;
 }

--- a/apps/dashboard/volto/color.css.ts
+++ b/apps/dashboard/volto/color.css.ts
@@ -1,4 +1,4 @@
-export const primaryPallete = {
+const primary = {
   0: '#000000',
   10: '#00105c',
   20: '#08218a',
@@ -17,7 +17,7 @@ export const primaryPallete = {
   100: '#ffffff',
 };
 
-export const neutral = {
+const neutral = {
   0: '#000000',
   10: '#121212',
   20: '#1f1f1f',
@@ -36,7 +36,7 @@ export const neutral = {
   100: '#ffffff',
 };
 
-export const background = {
+const background = {
   $: neutral[98], // hsl(0, 0, 96%)
   hovered: '#f1f1f1', // hsl(0, 0, 95%)
   pressed: '#ececec', // hsl(0, 0, 93%)
@@ -44,19 +44,28 @@ export const background = {
   transparent: 'transparent',
 };
 
-export const surface = {
+const surface = {
   $: neutral[100],
 };
 
-export const text = {
+const text = {
   $: neutral[35],
   muted: neutral[70],
   // disabled: '#8c9196',
   primary: {
-    $: primaryPallete[35], // hsl(230, 52%, 44%)
+    $: primary[35], // hsl(230, 52%, 44%)
     // hovered: '#32449f', // hsl(230, 52%, 41%)
     // pressed: '#2f3f93', // hsl(230, 52%, 38%)
   },
 };
 
-export const divider = neutral[95];
+const divider = neutral[95];
+
+export const color = {
+  primary,
+  neutral,
+  background,
+  surface,
+  text,
+  divider,
+};

--- a/apps/dashboard/volto/root.css.ts
+++ b/apps/dashboard/volto/root.css.ts
@@ -1,10 +1,10 @@
+import {border} from '@/volto/border.css';
+import * as color from '@/volto/color.css';
 import {createGlobalTheme} from '@vanilla-extract/css';
-import * as border from './border.css';
-import * as color from './color.css';
 
 export const vars = createGlobalTheme(':root', {
   border: {
-    divider: `${border.width[1]} solid ${color.divider}`,
+    divider: border.solid(1, color.divider),
     radius: '0.375rem',
   },
   size: {

--- a/apps/dashboard/volto/root.css.ts
+++ b/apps/dashboard/volto/root.css.ts
@@ -1,5 +1,5 @@
 import {border} from '@/volto/border.css';
-import * as color from '@/volto/color.css';
+import {color} from '@/volto/color.css';
 import {createGlobalTheme} from '@vanilla-extract/css';
 
 export const vars = createGlobalTheme(':root', {


### PR DESCRIPTION
Safari does not apply border radius to outline.
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/3942264/206884844-fef2aebb-5aff-49b8-8363-dd9500e43884.png">

Fix by switching to implement focus outline with `box-shadow`.

Also, refactor Volto css token modules `border`, (add) `boxShadow`, `color` so the import is consistent and make IDE auto import works.
