### PR TITLE
[dashboard] Unship property name

### DIFF
--- a/apps/dashboard/components/PropertySummary/PropertySummary.tsx
+++ b/apps/dashboard/components/PropertySummary/PropertySummary.tsx
@@ -13,11 +13,11 @@ type PropertySummaryProps = {
 };
 
 export function PropertySummary({
-  property: {coverImageUrl, name, address},
+  property: {coverImageUrl, address},
 }: PropertySummaryProps) {
   return (
     <Card as="article">
-      <Cover image={coverImageUrl} caption={name} />
+      <Cover image={coverImageUrl} caption={address.line1} />
       <div className={s.Body}>
         <div>
           <p className={s.Title}>
@@ -35,7 +35,7 @@ export function PropertySummary({
   );
 }
 
-function Cover({image, caption}: {image?: string; caption: string}) {
+function Cover({image, caption = ''}: {image?: string; caption?: string}) {
   return (
     <AspectRatio as="figure" ratio="2:1" className={s.Cover}>
       {image ? (

--- a/apps/dashboard/pages/properties/new.tsx
+++ b/apps/dashboard/pages/properties/new.tsx
@@ -71,7 +71,6 @@ function toPropertyData(
     const unit = detailsForm.singleFamily.toJSON();
     return {
       type: propertyType,
-      name: address.line1, // TEMPORARY
       address: address,
       ...unit,
       size: stringInputToNumber(unit.size),
@@ -82,7 +81,6 @@ function toPropertyData(
   const {units} = detailsForm.multiFamily;
   return {
     type: propertyType,
-    name: address.line1, // TEMPORARY
     address: address,
     units: units.map((unit) => ({
       ...unit,

--- a/apps/dashboard/services/property/LocalPropertyService.ts
+++ b/apps/dashboard/services/property/LocalPropertyService.ts
@@ -31,7 +31,6 @@ const DEMO_PROPERTIES: {[id: string]: PropertyModel} = {
   '1029599': {
     id: '1029599',
     type: 'single-family',
-    name: '527 Bridle Street',
     coverImageUrl: '/images/pexels-scott-webb-1029599.jpg',
     address: {
       line1: '527 Bridle Street',
@@ -43,7 +42,6 @@ const DEMO_PROPERTIES: {[id: string]: PropertyModel} = {
   '2724749': {
     id: '2724749',
     type: 'single-family',
-    name: '495 Ohio Street',
     coverImageUrl: '/images/pexels-mark-mccammon-2724749.jpg',
     address: {
       line1: '495 Ohio Street',
@@ -55,7 +53,6 @@ const DEMO_PROPERTIES: {[id: string]: PropertyModel} = {
   '3288102': {
     id: '3288102',
     type: 'single-family',
-    name: '9026 Washington Dr.',
     coverImageUrl: '/images/pexels-curtis-adams-3288102.jpg',
     address: {
       line1: '9026 Washington Dr.',
@@ -67,7 +64,6 @@ const DEMO_PROPERTIES: {[id: string]: PropertyModel} = {
   '9999990': {
     id: '9999990',
     type: 'single-family',
-    name: '9189 South Argyle Dr.',
     address: {
       line1: '9189 South Argyle Dr.',
       city: 'Natchez',
@@ -78,7 +74,6 @@ const DEMO_PROPERTIES: {[id: string]: PropertyModel} = {
   '9999991': {
     id: '9999991',
     type: 'single-family',
-    name: '9189 South Argyle Dr.',
     address: {
       line1: '9189 South Argyle Dr.',
       city: 'Natchez',
@@ -89,7 +84,6 @@ const DEMO_PROPERTIES: {[id: string]: PropertyModel} = {
   '9999992': {
     id: '9999992',
     type: 'single-family',
-    name: '9189 South Argyle Dr.',
     address: {
       line1: '9189 South Argyle Dr.',
       city: 'Natchez',

--- a/apps/dashboard/services/property/PropertyModel.ts
+++ b/apps/dashboard/services/property/PropertyModel.ts
@@ -7,7 +7,6 @@ export type PropertyData = SingleFamilyProperty | MultiFamilyProperty;
 
 export type SingleFamilyProperty = {
   type: 'single-family';
-  name: string;
   coverImageUrl?: string;
   address: AddressModel;
   builtYear?: number;
@@ -20,7 +19,6 @@ export type SingleFamilyProperty = {
 
 export type MultiFamilyProperty = {
   type: 'multi-family';
-  name: string;
   coverImageUrl?: string;
   address: AddressModel;
   builtYear?: number;


### PR DESCRIPTION
### Why
- We currently don't know a use case that a landlord would want to give a property a custom name; we can add once we know what it helps users accomplish.
- Removing it reduce the amount of information we ask from users thus keeping the app simple.

### What
- Remove `name` from `PropertyModel`, `property.address.line1` is used as the "name" instead.