### PR TITLE
[dashboard] Improve data fetching and invalidation

### DIFF
--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/PropertyInfo.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/PropertyInfo.tsx
@@ -21,7 +21,7 @@ export function PropertyInfo(props: PropertyInfoProps) {
   const {data, mutate: mutateProperty} = useSWR(
     `/api/property/${props.property.id}`,
     async () => {
-      const p = await propertySvc.get(props.property.id);
+      const p = await propertySvc.getById(props.property.id);
       return p?.type === 'multi-family' ? p : undefined;
     }
   );
@@ -94,10 +94,12 @@ function Editing({
           variant="contained"
           // TODO: disable button and show loading state
           onClick={async () => {
+            const d = toPropertyModel(address.fields);
             try {
-              const d = toPropertyModel(address.fields);
               const updated = await propertySvc.update(property.id, d);
               onUpdateSuccess(updated);
+            } catch (err) {
+              console.error('Cannot update property', err);
             } finally {
               onUpdateSettled();
             }

--- a/apps/dashboard/components/PropertyForm.tsx
+++ b/apps/dashboard/components/PropertyForm.tsx
@@ -2,11 +2,10 @@ import {Select, toOption} from '@/volto/Select';
 import {ComponentPropsWithoutRef, useMemo} from 'react';
 
 type Props = {
-  name: string;
   onChange: (selection: number | undefined) => void;
 } & Pick<ComponentPropsWithoutRef<typeof Select>, 'value'>;
 
-export function BedroomsSelect({name, value, onChange}: Props) {
+export function BedroomsSelect({value, onChange}: Props) {
   const options = useMemo(
     () => [{label: 'Studio', value: 0}, ...[1, 2, 3, 4, 5].map(toOption)],
     []
@@ -15,7 +14,6 @@ export function BedroomsSelect({name, value, onChange}: Props) {
   return (
     <Select
       label="Beds"
-      name={name}
       options={options}
       value={value}
       onChange={(e) => {
@@ -26,7 +24,7 @@ export function BedroomsSelect({name, value, onChange}: Props) {
   );
 }
 
-export function BathroomsSelect({name, value, onChange}: Props) {
+export function BathroomsSelect({value, onChange}: Props) {
   const options = useMemo(
     () => [
       {label: 'None', value: 0},
@@ -37,7 +35,6 @@ export function BathroomsSelect({name, value, onChange}: Props) {
   return (
     <Select
       label="Baths"
-      name={name}
       options={options}
       value={value}
       onChange={(e) => {

--- a/apps/dashboard/pages/properties/[id].tsx
+++ b/apps/dashboard/pages/properties/[id].tsx
@@ -21,6 +21,7 @@ export default function Page() {
   const {isLoading, data: property} = useSWR(
     `/api/properties/${propertyId}`,
     () =>
+      // this is undefined during SSR
       typeof propertyId === 'string' ? propertySvc.getById(propertyId) : null
   );
 

--- a/apps/dashboard/pages/properties/index.tsx
+++ b/apps/dashboard/pages/properties/index.tsx
@@ -39,7 +39,7 @@ export default function Page() {
 
 function PropertyList() {
   const propertySvc = usePropertyService();
-  const {data} = useSWR('properties', () => propertySvc.getAll());
+  const {data} = useSWR('/api/properties', () => propertySvc.getAll());
 
   const properties = data
     ? data.map((p) => (

--- a/apps/dashboard/pages/properties/new.tsx
+++ b/apps/dashboard/pages/properties/new.tsx
@@ -1,13 +1,13 @@
 import {
-  DetailsForm,
-  DetailsFormState,
-  useDetailsFormState,
-} from '@/components/NewProperty';
-import {
   AddressForm,
   AddressFormState,
   useAddressFormState,
 } from '@/components/AddressForm';
+import {
+  DetailsForm,
+  DetailsFormState,
+  useDetailsFormState,
+} from '@/components/NewProperty';
 import {PageLayout} from '@/layouts/Page';
 import {PageHeader} from '@/layouts/PageHeader';
 import {NewPropertyData, usePropertyService} from '@/services/property';
@@ -16,6 +16,7 @@ import {Section} from '@/volto/Section';
 import Head from 'next/head';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
+import useSWRMutation from 'swr/mutation';
 import * as s from './new.css';
 
 export default function Page() {
@@ -24,6 +25,11 @@ export default function Page() {
 
   const address = useAddressFormState();
   const details = useDetailsFormState();
+
+  const addPropertyMutation = useSWRMutation('/api/properties', () => {
+    const d = toNewPropertyData(address.fields, details);
+    return propertySvc.add(d);
+  });
 
   return (
     <>
@@ -51,11 +57,10 @@ export default function Page() {
           </Button>
           <Button
             variant="contained"
-            // TODO: validation
+            disabled={addPropertyMutation.isMutating}
             onClick={async () => {
-              const d = toNewPropertyData(address.fields, details);
               try {
-                const created = await propertySvc.add(d);
+                const created = await addPropertyMutation.trigger();
                 console.log('property created', created);
                 router.push('/properties');
               } catch (err) {

--- a/apps/dashboard/services/property/LocalPropertyService.ts
+++ b/apps/dashboard/services/property/LocalPropertyService.ts
@@ -11,18 +11,17 @@ export class LocalPropertyService implements PropertyService {
     return [...this.properties.values()];
   }
 
-  async get(id: string): Promise<PropertyModel | undefined> {
+  async getById(id: string): Promise<PropertyModel | undefined> {
     return this.properties.get(id);
   }
 
   async add(newPropertyData: NewPropertyData): Promise<PropertyModel> {
-    const id = nanoid();
     const p = withId(newPropertyData);
     const property: PropertyModel =
       p.type === 'single-family'
         ? {...p, unit: withId(p.unit)}
         : {...p, units: p.units.map(withId)};
-    this.properties.set(id, property);
+    this.properties.set(p.id, property);
     return property;
   }
 

--- a/apps/dashboard/services/property/PropertyService.ts
+++ b/apps/dashboard/services/property/PropertyService.ts
@@ -3,7 +3,7 @@ import {NewPropertyData, PropertyModel} from './PropertyModel';
 export interface PropertyService {
   getAll(): Promise<PropertyModel[]>;
 
-  get(id: string): Promise<PropertyModel | undefined>;
+  getById(id: string): Promise<PropertyModel | undefined>;
 
   // creates a new property from newPropertyData.
   // The service will assign the property id.

--- a/apps/dashboard/volto/Select.tsx
+++ b/apps/dashboard/volto/Select.tsx
@@ -12,7 +12,6 @@ type OwnSelectProps = {
   className?: string;
   // disabled?: boolean;
   label: string;
-  name: string;
   // required?: boolean;
   options: Option[];
 };
@@ -23,7 +22,6 @@ type SelectProps = OwnSelectProps &
 export function Select({
   className,
   label,
-  name,
   options,
   ...passthroughProps
 }: SelectProps) {
@@ -34,12 +32,7 @@ export function Select({
         {label}
       </label>
       <div className={s.InputWrapper}>
-        <select
-          {...passthroughProps}
-          className={s.Input}
-          id={fieldId}
-          name={name}
-        >
+        <select {...passthroughProps} className={s.Input} id={fieldId}>
           <option></option>
           {options.map((o) => (
             <option key={o.value} value={o.value}>

--- a/apps/dashboard/volto/TextField.tsx
+++ b/apps/dashboard/volto/TextField.tsx
@@ -6,26 +6,20 @@ type OwnTextFieldProps = {
   className?: string;
   // disabled?: boolean;
   label: string;
-  name: string;
   // required?: boolean;
 };
 
 type TextFieldProps = OwnTextFieldProps &
   Omit<InputHTMLAttributes<HTMLInputElement>, keyof OwnTextFieldProps>;
 
-export function TextField({
-  className,
-  label,
-  name,
-  ...inputProps
-}: TextFieldProps) {
+export function TextField({className, label, ...inputProps}: TextFieldProps) {
   const fieldId = useId();
   return (
     <div className={clsx(s.TextField, className)}>
       <label className={s.Label} htmlFor={fieldId}>
         {label}
       </label>
-      <input {...inputProps} className={s.Input} id={fieldId} name={name} />
+      <input {...inputProps} className={s.Input} id={fieldId} />
     </div>
   );
 }


### PR DESCRIPTION
- fix added property doesn't show up when using `LocalPropertyService` (due to SSR)
- adding a new property invalidates propertyList
- `TextField` and `Select` (plus: `BedroomsSelect` and `BathroomsSelect`) no longer requires `name` props