### PR TITLE
[dashboard] automate organize imports with prettier

### DIFF
--- a/apps/dashboard/.prettierignore
+++ b/apps/dashboard/.prettierignore
@@ -1,0 +1,2 @@
+.next/
+node_modules/

--- a/apps/dashboard/.vscode/extensions.json
+++ b/apps/dashboard/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
-    "esbenp.prettier-vscode",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/apps/dashboard/components/AddressForm.css.ts
+++ b/apps/dashboard/components/AddressForm.css.ts
@@ -1,5 +1,5 @@
 import {unit} from '@/volto/spacing.css';
-import {style, styleVariants} from '@vanilla-extract/css';
+import {styleVariants} from '@vanilla-extract/css';
 
 export const layout = styleVariants({
   oneColumn: {

--- a/apps/dashboard/components/AppShell/MainNav.css.ts
+++ b/apps/dashboard/components/AppShell/MainNav.css.ts
@@ -1,5 +1,5 @@
-import {unit} from '@/volto/spacing.css';
 import {vars} from '@/volto/root.css';
+import {unit} from '@/volto/spacing.css';
 import {style} from '@vanilla-extract/css';
 
 export const MainNav = style({

--- a/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/UnitEntry.css.ts
+++ b/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/UnitEntry.css.ts
@@ -1,5 +1,3 @@
-import {color} from '@/volto/color.css';
-import {vars} from '@/volto/root.css';
 import {unit} from '@/volto/spacing.css';
 import {font} from '@/volto/typography.css';
 import {style} from '@vanilla-extract/css';

--- a/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
@@ -1,5 +1,5 @@
 import {PropertyType} from '@/services/property';
-import {Radio, useRadio, useRadioGroup, RadioGroupState} from '@/volto/Radio';
+import {Radio, RadioGroupState, useRadio, useRadioGroup} from '@/volto/Radio';
 import {useFocusRing} from '@react-aria/focus';
 import clsx from 'clsx';
 import {useId, useRef} from 'react';

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@vanilla-extract/next-plugin": "2.1.1",
-    "prettier": "2.8.4"
+    "prettier": "2.8.4",
+    "prettier-plugin-organize-imports": "3.2.2"
   }
 }

--- a/apps/dashboard/pages/_app.css
+++ b/apps/dashboard/pages/_app.css
@@ -1,4 +1,4 @@
-@import "normalize.css";
+@import 'normalize.css';
 
 *,
 :after,
@@ -19,7 +19,8 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+    sans-serif;
   min-height: 100%;
 }
 
@@ -59,7 +60,7 @@ pre,
 code,
 kbd,
 samp {
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
   font-size: 1em;
 }
 

--- a/apps/dashboard/volto/Tooltip/Tooltip.tsx
+++ b/apps/dashboard/volto/Tooltip/Tooltip.tsx
@@ -1,8 +1,8 @@
 import {AriaPositionProps, useOverlayPosition} from '@react-aria/overlays';
 import {PropsWithChildren, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
-import {useTooltipsManager} from './TooltipsManager';
 import * as s from './Tooltip.css';
+import {useTooltipsManager} from './TooltipsManager';
 
 export type TooltipProps = PropsWithChildren<{
   id: string;

--- a/apps/dashboard/yarn.lock
+++ b/apps/dashboard/yarn.lock
@@ -2499,6 +2499,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier-plugin-organize-imports@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz#91993365e017daa5d0d28d8183179834224d8dd1"
+  integrity sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==
+
 prettier@2.8.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"


### PR DESCRIPTION
- Add `prettier-plugin-organize-imports` to organize imports via prettier
- Run `yarn prettier -w .`