### PR TITLE
[dashboard] run CI for any path

### DIFF
--- a/.github/workflows/apps.dashboard.ci.yml
+++ b/.github/workflows/apps.dashboard.ci.yml
@@ -2,8 +2,6 @@ name: apps/dashboard
 
 on:
   pull_request:
-    paths:
-      - apps/dashboard/**
 
 jobs:
   ci:


### PR DESCRIPTION
Run CI for changes anywhere in the `mono` repo since we requires the check to report in order to merge.

<img width="771" alt="image" src="https://user-images.githubusercontent.com/3942264/226089947-11b535dc-f5fa-4be1-b657-4bc0dd38a45c.png">

Do this until we figure out how to conditionally "require" merge check in GH.