### PR TITLE
[dashboard] Only run CI for related changes

### DIFF
--- a/.github/workflows/apps.dashboard.ci-skip.yaml
+++ b/.github/workflows/apps.dashboard.ci-skip.yaml
@@ -1,0 +1,15 @@
+name: apps/dashboard
+
+on:
+  pull_request:
+    paths-ignore:
+      - apps/dashboard/**
+
+jobs:
+  ci:
+    name: Skip due to unrelated change
+    runs-on: ubuntu-latest
+    permissions:
+      contents: none
+    steps:
+      - run: 'echo "Skip due to unrelated change"'

--- a/.github/workflows/apps.dashboard.ci.yml
+++ b/.github/workflows/apps.dashboard.ci.yml
@@ -2,6 +2,8 @@ name: apps/dashboard
 
 on:
   pull_request:
+    paths:
+      - apps/dashboard/**
 
 jobs:
   ci:


### PR DESCRIPTION
Fix the issue as described in https://github.com/hausops/mono/pull/34 i.e. required checks for `apps/dashboard` never reports when using GH workflow path filtering preventing merge.

This fix follows: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks