### PR TITLE
[dashboard-api] Propagate context to property service

### DIFF
--- a/apps/dashboard-api/adapter/dapr/property.go
+++ b/apps/dashboard-api/adapter/dapr/property.go
@@ -23,20 +23,25 @@ func NewPropertyService(grpcConn *grpc.ClientConn) *PropertyService {
 	}
 }
 
-func (r *PropertyService) CreateSingleFamilyProperty(in property.CreateSingleFamilyPropertyInput) (*property.SingleFamilyProperty, error) {
+func (r *PropertyService) CreateSingleFamilyProperty(
+	_ context.Context,
+	in property.CreateSingleFamilyPropertyInput,
+) (*property.SingleFamilyProperty, error) {
 	panic("Not implemented - dapr.PropertyService.CreateSingleFamilyProperty")
 }
 
-func (r *PropertyService) CreateMultiFamilyProperty(in property.CreateMultiFamilyPropertyInput) (*property.MultiFamilyProperty, error) {
+func (r *PropertyService) CreateMultiFamilyProperty(
+	_ context.Context,
+	in property.CreateMultiFamilyPropertyInput,
+) (*property.MultiFamilyProperty, error) {
 	panic("Not implemented - dapr.PropertyService.CreateMultiFamilyProperty")
 }
 
-func (r *PropertyService) FindByID(id string) (property.Property, error) {
+func (r *PropertyService) FindByID(_ context.Context, id string) (property.Property, error) {
 	panic("Not implemented - dapr.PropertyService.FindByID")
 }
 
-func (r *PropertyService) FindAll() ([]property.Property, error) {
-	ctx := context.TODO()
+func (r *PropertyService) FindAll(ctx context.Context) ([]property.Property, error) {
 	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-app-id", "property-svc")
 
 	res, err := r.client.List(ctx, &emptypb.Empty{})
@@ -163,6 +168,7 @@ func decodeAddress(in *pb.Address) property.Address {
 }
 
 func (r *PropertyService) UpdateSingleFamilyPropertyByID(
+	_ context.Context,
 	id string,
 	in property.UpdateSingleFamilyPropertyInput,
 ) (*property.SingleFamilyProperty, error) {
@@ -170,12 +176,13 @@ func (r *PropertyService) UpdateSingleFamilyPropertyByID(
 }
 
 func (r *PropertyService) UpdateMultiFamilyPropertyByID(
+	_ context.Context,
 	id string,
 	in property.UpdateMultiFamilyPropertyInput,
 ) (*property.MultiFamilyProperty, error) {
 	panic("Not implemented - dapr.PropertyService.UpdateMultiFamilyPropertyByID")
 }
 
-func (r *PropertyService) DeleteByID(id string) (property.Property, error) {
+func (r *PropertyService) DeleteByID(_ context.Context, id string) (property.Property, error) {
 	panic("Not implemented - dapr.PropertyService.DeleteByID")
 }

--- a/apps/dashboard-api/adapter/local/property.go
+++ b/apps/dashboard-api/adapter/local/property.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"errors"
 
 	"github.com/google/uuid"
@@ -18,7 +19,10 @@ func NewPropertyService() *PropertyService {
 	return &PropertyService{byId: make(map[string]property.Property)}
 }
 
-func (r *PropertyService) CreateSingleFamilyProperty(in property.CreateSingleFamilyPropertyInput) (*property.SingleFamilyProperty, error) {
+func (r *PropertyService) CreateSingleFamilyProperty(
+	_ context.Context,
+	in property.CreateSingleFamilyPropertyInput,
+) (*property.SingleFamilyProperty, error) {
 	unit := property.SingleFamilyPropertyUnit{
 		ID:         uuid.New().String(),
 		Bedrooms:   in.Unit.Bedrooms,
@@ -38,7 +42,10 @@ func (r *PropertyService) CreateSingleFamilyProperty(in property.CreateSingleFam
 	return &p, nil
 }
 
-func (r *PropertyService) CreateMultiFamilyProperty(in property.CreateMultiFamilyPropertyInput) (*property.MultiFamilyProperty, error) {
+func (r *PropertyService) CreateMultiFamilyProperty(
+	_ context.Context,
+	in property.CreateMultiFamilyPropertyInput,
+) (*property.MultiFamilyProperty, error) {
 	units := make([]property.MultiFamilyPropertyUnit, 0, len(in.Units))
 	for _, iu := range in.Units {
 		u := property.MultiFamilyPropertyUnit{
@@ -63,7 +70,7 @@ func (r *PropertyService) CreateMultiFamilyProperty(in property.CreateMultiFamil
 	return &p, nil
 }
 
-func (r *PropertyService) FindByID(id string) (property.Property, error) {
+func (r *PropertyService) FindByID(_ context.Context, id string) (property.Property, error) {
 	p, ok := r.byId[id]
 	if !ok {
 		return nil, property.NotFoundError{ID: id}
@@ -71,7 +78,7 @@ func (r *PropertyService) FindByID(id string) (property.Property, error) {
 	return p, nil
 }
 
-func (r *PropertyService) FindAll() ([]property.Property, error) {
+func (r *PropertyService) FindAll(_ context.Context) ([]property.Property, error) {
 	ps := make([]property.Property, 0, len(r.byId))
 	for _, p := range r.byId {
 		ps = append(ps, p)
@@ -80,6 +87,7 @@ func (r *PropertyService) FindAll() ([]property.Property, error) {
 }
 
 func (r *PropertyService) UpdateSingleFamilyPropertyByID(
+	_ context.Context,
 	id string,
 	in property.UpdateSingleFamilyPropertyInput,
 ) (*property.SingleFamilyProperty, error) {
@@ -99,6 +107,7 @@ func (r *PropertyService) UpdateSingleFamilyPropertyByID(
 }
 
 func (r *PropertyService) UpdateMultiFamilyPropertyByID(
+	_ context.Context,
 	id string,
 	in property.UpdateMultiFamilyPropertyInput,
 ) (*property.MultiFamilyProperty, error) {
@@ -117,7 +126,7 @@ func (r *PropertyService) UpdateMultiFamilyPropertyByID(
 	return &mp, nil
 }
 
-func (r *PropertyService) DeleteByID(id string) (property.Property, error) {
+func (r *PropertyService) DeleteByID(_ context.Context, id string) (property.Property, error) {
 	p, ok := r.byId[id]
 	if !ok {
 		return nil, property.NotFoundError{ID: id}

--- a/apps/dashboard-api/domain/property/service.go
+++ b/apps/dashboard-api/domain/property/service.go
@@ -1,29 +1,35 @@
 package property
 
+import "context"
+
 type Service interface {
 	CreateSingleFamilyProperty(
-		CreateSingleFamilyPropertyInput,
+		ctx context.Context,
+		in CreateSingleFamilyPropertyInput,
 	) (*SingleFamilyProperty, error)
 
 	CreateMultiFamilyProperty(
-		CreateMultiFamilyPropertyInput,
+		ctx context.Context,
+		in CreateMultiFamilyPropertyInput,
 	) (*MultiFamilyProperty, error)
 
-	FindByID(id string) (Property, error)
+	FindByID(ctx context.Context, id string) (Property, error)
 
-	FindAll() ([]Property, error)
+	FindAll(ctx context.Context) ([]Property, error)
 
 	UpdateSingleFamilyPropertyByID(
+		ctx context.Context,
 		id string,
-		input UpdateSingleFamilyPropertyInput,
+		in UpdateSingleFamilyPropertyInput,
 	) (*SingleFamilyProperty, error)
 
 	UpdateMultiFamilyPropertyByID(
+		ctx context.Context,
 		id string,
-		input UpdateMultiFamilyPropertyInput,
+		in UpdateMultiFamilyPropertyInput,
 	) (*MultiFamilyProperty, error)
 
-	DeleteByID(id string) (Property, error)
+	DeleteByID(ctx context.Context, id string) (Property, error)
 }
 
 type CreateSingleFamilyPropertyInput struct {

--- a/apps/dashboard-api/graphql/schema.resolvers.go
+++ b/apps/dashboard-api/graphql/schema.resolvers.go
@@ -13,27 +13,27 @@ import (
 
 // CreateSingleFamilyProperty is the resolver for the createSingleFamilyProperty field.
 func (r *mutationResolver) CreateSingleFamilyProperty(ctx context.Context, input property.CreateSingleFamilyPropertyInput) (*property.SingleFamilyProperty, error) {
-	return r.PropertySvc.CreateSingleFamilyProperty(input)
+	return r.PropertySvc.CreateSingleFamilyProperty(ctx, input)
 }
 
 // CreateMultiFamilyProperty is the resolver for the createMultiFamilyProperty field.
 func (r *mutationResolver) CreateMultiFamilyProperty(ctx context.Context, input property.CreateMultiFamilyPropertyInput) (*property.MultiFamilyProperty, error) {
-	return r.PropertySvc.CreateMultiFamilyProperty(input)
+	return r.PropertySvc.CreateMultiFamilyProperty(ctx, input)
 }
 
 // UpdateSingleFamilyProperty is the resolver for the updateSingleFamilyProperty field.
 func (r *mutationResolver) UpdateSingleFamilyProperty(ctx context.Context, id string, input property.UpdateSingleFamilyPropertyInput) (*property.SingleFamilyProperty, error) {
-	return r.PropertySvc.UpdateSingleFamilyPropertyByID(id, input)
+	return r.PropertySvc.UpdateSingleFamilyPropertyByID(ctx, id, input)
 }
 
 // UpdateMultiFamilyProperty is the resolver for the updateMultiFamilyProperty field.
 func (r *mutationResolver) UpdateMultiFamilyProperty(ctx context.Context, id string, input property.UpdateMultiFamilyPropertyInput) (*property.MultiFamilyProperty, error) {
-	return r.PropertySvc.UpdateMultiFamilyPropertyByID(id, input)
+	return r.PropertySvc.UpdateMultiFamilyPropertyByID(ctx, id, input)
 }
 
 // DeleteProperty is the resolver for the deleteProperty field.
 func (r *mutationResolver) DeleteProperty(ctx context.Context, id string) (property.Property, error) {
-	return r.PropertySvc.DeleteByID(id)
+	return r.PropertySvc.DeleteByID(ctx, id)
 }
 
 // Property is the resolver for the property field.
@@ -43,7 +43,7 @@ func (r *queryResolver) Property(ctx context.Context, id string) (property.Prope
 
 // Properties is the resolver for the properties field.
 func (r *queryResolver) Properties(ctx context.Context) ([]property.Property, error) {
-	return r.PropertySvc.FindAll()
+	return r.PropertySvc.FindAll(ctx)
 }
 
 // Mutation returns MutationResolver implementation.


### PR DESCRIPTION
Methods on `property.Service` take `context.Context` in order to propagate it further downstream.