### PR TITLE
[property-svc] refactor: grpcserver dependencies clean-up

### DIFF
--- a/services/property-svc/config/config.go
+++ b/services/property-svc/config/config.go
@@ -21,7 +21,7 @@ func (c *Config) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	if err := node.Decode(&config); err != nil {
-		return err
+		return fmt.Errorf("decode config from YAML: %w", err)
 	}
 
 	// Set mode
@@ -35,7 +35,7 @@ func (c *Config) UnmarshalYAML(node *yaml.Node) error {
 		var mongo MongoDatastore
 		spec := config.Datastore["spec"]
 		if err := spec.Decode(&mongo); err != nil {
-			return err
+			return fmt.Errorf("decode datastore spec from YAML: %w", err)
 		}
 		c.Datastore = mongo
 	default:
@@ -49,7 +49,7 @@ func (c *Config) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (c Config) Validate() error {
+func (c *Config) Validate() error {
 	switch c.Mode {
 	case ModeProd, ModeDev:
 	default:

--- a/services/property-svc/go.mod
+++ b/services/property-svc/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	go.mongodb.org/mongo-driver v1.11.6
 	go.uber.org/zap v1.24.0
+	golang.org/x/sync v0.2.0
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -29,7 +30,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect

--- a/services/property-svc/go.sum
+++ b/services/property-svc/go.sum
@@ -120,8 +120,9 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/services/property-svc/grpcserver/dependencies.go
+++ b/services/property-svc/grpcserver/dependencies.go
@@ -2,6 +2,7 @@ package grpcserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,16 +10,13 @@ import (
 	"github.com/hausops/mono/services/property-svc/adapter/mongo"
 	"github.com/hausops/mono/services/property-svc/config"
 	"github.com/hausops/mono/services/property-svc/domain/property"
+	"golang.org/x/sync/errgroup"
 )
 
 type dependencies struct {
-	propertySvc *property.Service
-	cleanUp     func(context.Context) error
+	propertySvc   *property.Service
+	closeHandlers []func(context.Context) error
 }
-
-// type dependency interface {
-// 	cleanUp(context.Context) error
-// }
 
 func newDependencies(ctx context.Context, c config.Config) (*dependencies, error) {
 	var deps dependencies
@@ -30,26 +28,51 @@ func newDependencies(ctx context.Context, c config.Config) (*dependencies, error
 
 		deps = dependencies{
 			propertySvc: property.NewService(propertyRepo),
-			cleanUp:     func(_ context.Context) error { return nil },
 		}
 
 	case config.MongoDatastore:
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 
-		mongoClient, err := mongo.Conn(ctx, t.URI)
+		c, err := mongo.Conn(ctx, t.URI)
 		if err != nil {
 			return nil, fmt.Errorf("connect to mongo: %w", err)
 		}
-		propertyRepo := mongo.NewPropertyRepository(mongoClient)
+
+		deps.onClose(func(ctx context.Context) error {
+			return c.Disconnect(ctx)
+		})
+
+		propertyRepo := mongo.NewPropertyRepository(c)
 
 		deps = dependencies{
 			propertySvc: property.NewService(propertyRepo),
-			cleanUp: func(ctx context.Context) error {
-				return mongoClient.Disconnect(ctx)
-			},
 		}
 	}
 
+	if err := deps.validate(); err != nil {
+		return nil, fmt.Errorf("invalid dependencies: %w", err)
+	}
+
 	return &deps, nil
+}
+
+func (d *dependencies) validate() error {
+	if d.propertySvc == nil {
+		return errors.New("property service is not set")
+	}
+	return nil
+}
+
+func (d *dependencies) onClose(h func(context.Context) error) {
+	d.closeHandlers = append(d.closeHandlers, h)
+}
+
+func (d *dependencies) close(ctx context.Context) error {
+	var g errgroup.Group
+	for _, h := range d.closeHandlers {
+		h := h // https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() error { return h(ctx) })
+	}
+	return g.Wait()
 }

--- a/services/property-svc/grpcserver/grpcserver.go
+++ b/services/property-svc/grpcserver/grpcserver.go
@@ -63,7 +63,7 @@ func (s *server) GracefulStop(ctx context.Context) {
 	}
 
 	s.logger.Info("Cleaning up dependencies")
-	if err := s.deps.cleanUp(ctx); err != nil {
+	if err := s.deps.close(ctx); err != nil {
 		s.logger.Error("Error cleaning up dependencies", zap.Error(err))
 	} else {
 		s.logger.Info("Successfully cleaned up dependencies")


### PR DESCRIPTION
- Make register clean-up function in `grpcserver.dependencies` easier (use the design from https://github.com/hausops/mono/pull/51)
- Use `errgroup.Group` to handle `grpcserver.dependencies.close` errors