### PR TITLE
[user-svc] create user.ID type

### DIFF
--- a/services/user-svc/adapter/local/user.go
+++ b/services/user-svc/adapter/local/user.go
@@ -5,15 +5,14 @@ import (
 	"net/mail"
 
 	"github.com/hausops/mono/services/user-svc/domain/user"
-	"github.com/rs/xid"
 )
 
 type userRepository struct {
 	// byID maps user ID to user.User.
-	byID map[xid.ID]user.User
+	byID map[user.ID]user.User
 
 	// byEmail maps email address to user ID.
-	byEmail map[mail.Address]xid.ID
+	byEmail map[mail.Address]user.ID
 }
 
 // NewUserRepository creates a new instance of the userRepository with
@@ -22,15 +21,15 @@ type userRepository struct {
 // The returned user repository can be used to store and retrieve user information.
 func NewUserRepository() *userRepository {
 	return &userRepository{
-		byID:    make(map[xid.ID]user.User),
-		byEmail: make(map[mail.Address]xid.ID),
+		byID:    make(map[user.ID]user.User),
+		byEmail: make(map[mail.Address]user.ID),
 	}
 }
 
 // Ensure userRepository implements the user.Repository interface.
 var _ user.Repository = (*userRepository)(nil)
 
-func (r *userRepository) Delete(ctx context.Context, id xid.ID) (user.User, error) {
+func (r *userRepository) Delete(ctx context.Context, id user.ID) (user.User, error) {
 	u, ok := r.byID[id]
 	if !ok {
 		return user.User{}, user.ErrNotFound
@@ -40,7 +39,7 @@ func (r *userRepository) Delete(ctx context.Context, id xid.ID) (user.User, erro
 	return u, nil
 }
 
-func (r *userRepository) FindByID(ctx context.Context, id xid.ID) (user.User, error) {
+func (r *userRepository) FindByID(ctx context.Context, id user.ID) (user.User, error) {
 	u, ok := r.byID[id]
 	if !ok {
 		return user.User{}, user.ErrNotFound

--- a/services/user-svc/adapter/mongo/user.go
+++ b/services/user-svc/adapter/mongo/user.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hausops/mono/services/user-svc/domain/user"
-	"github.com/rs/xid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -57,7 +56,7 @@ func createEmailIndex(ctx context.Context, userCollection *mongo.Collection) err
 // Ensure userRepository implements the user.Repository interface.
 var _ user.Repository = (*userRepository)(nil)
 
-func (r *userRepository) Delete(ctx context.Context, id xid.ID) (user.User, error) {
+func (r *userRepository) Delete(ctx context.Context, id user.ID) (user.User, error) {
 	var u userBSON
 	err := r.collection.FindOneAndDelete(ctx, bson.M{"_id": id}).Decode(&u)
 	if err != nil {
@@ -71,7 +70,7 @@ func (r *userRepository) Delete(ctx context.Context, id xid.ID) (user.User, erro
 	return u.toUser(), nil
 }
 
-func (r *userRepository) FindByID(ctx context.Context, id xid.ID) (user.User, error) {
+func (r *userRepository) FindByID(ctx context.Context, id user.ID) (user.User, error) {
 	var u userBSON
 	err := r.collection.FindOne(ctx, bson.M{"_id": id}).Decode(&u)
 	if err != nil {
@@ -100,7 +99,7 @@ func (r *userRepository) FindByEmail(ctx context.Context, email mail.Address) (u
 }
 
 func (r *userRepository) Upsert(ctx context.Context, u user.User) (user.User, error) {
-	if u.ID == (xid.ID{}) {
+	if u.ID.IsZero() {
 		return user.User{}, user.ErrMissingID
 	}
 
@@ -134,7 +133,7 @@ func (r *userRepository) Upsert(ctx context.Context, u user.User) (user.User, er
 }
 
 type userBSON struct {
-	ID          xid.ID       `bson:"_id"`
+	ID          user.ID      `bson:"_id"`
 	Email       mail.Address `bson:"email"`
 	DateCreated time.Time    `bson:"date_created"`
 	DateUpdated time.Time    `bson:"date_updated"`

--- a/services/user-svc/domain/user/id.go
+++ b/services/user-svc/domain/user/id.go
@@ -1,0 +1,27 @@
+package user
+
+import "github.com/rs/xid"
+
+type ID xid.ID
+
+// NewID creates a new non-empty ID.
+func NewID() ID {
+	return ID(xid.New())
+}
+
+// ParseID parse s to ID or an error if s is not a valid ID.
+func ParseID(s string) (ID, error) {
+	id, err := xid.FromString(s)
+	if err != nil {
+		return ID{}, ErrInvalidID
+	}
+	return ID(id), nil
+}
+
+func (id ID) IsZero() bool {
+	return xid.ID(id).IsZero()
+}
+
+func (id ID) String() string {
+	return xid.ID(id).String()
+}

--- a/services/user-svc/domain/user/id_test.go
+++ b/services/user-svc/domain/user/id_test.go
@@ -1,0 +1,102 @@
+package user_test
+
+import (
+	"testing"
+
+	"github.com/hausops/mono/services/user-svc/domain/user"
+)
+
+func TestNewID(t *testing.T) {
+	id := user.NewID()
+	if id.IsZero() {
+		t.Error("user.NewID() generates an empty (zero) ID")
+	}
+}
+
+func TestParseID(t *testing.T) {
+	t.Run("Invalid ID", func(t *testing.T) {
+		for _, idStr := range []string{
+			"",
+			"123",
+			"ci6qsgrvq9l872j5bc8",
+		} {
+			_, err := user.ParseID(idStr)
+			if err != user.ErrInvalidID {
+				t.Errorf("user.ParseID(%q) error = %v, want: ErrInvalidID", idStr, err)
+			}
+		}
+	})
+
+	t.Run("Valid ID", func(t *testing.T) {
+		for _, idStr := range []string{
+			"ci6qsgrvq9l872j5bc80",
+			"00000000000000000000",
+		} {
+			id, err := user.ParseID(idStr)
+			if err != nil {
+				t.Errorf("user.ParseID(%s) error = %v, want no error", idStr, err)
+			}
+			id2, _ := user.ParseID(id.String())
+			if id != id2 {
+				t.Error("Parsed ID from the same string are not equal")
+			}
+		}
+	})
+}
+
+func TestID_IsZero(t *testing.T) {
+	var empty user.ID
+	if !empty.IsZero() {
+		t.Error("emptyID.IsZero() = false, want true")
+	}
+
+	id := user.NewID()
+	if id.IsZero() {
+		t.Errorf("ID{%s}.IsZero() = true, want false", id)
+	}
+}
+
+func TestID_String(t *testing.T) {
+	// empty ID
+	{
+		const emptyIDStr = "00000000000000000000"
+
+		var empty user.ID
+		{
+			got := empty.String()
+			if got != emptyIDStr {
+				t.Errorf("emptyID.String() = %s, want %s", got, emptyIDStr)
+			}
+		}
+
+		parsedEmpty, err := user.ParseID(emptyIDStr)
+		if err != nil {
+			t.Fatalf("user.ParseID(%s) error = %v", emptyIDStr, err)
+		}
+		{
+			got := parsedEmpty.String()
+			if got != emptyIDStr {
+				t.Errorf("parsedEmpty.String() = %s, want %s", got, emptyIDStr)
+			}
+		}
+
+		// Literal creation is equivalent to parsing from the empty ID string.
+		if empty != parsedEmpty {
+			t.Error("empty != parsedEmpty")
+		}
+	}
+
+	// non-empty ID
+	{
+		idStr := "cio035jjtoj2i2fbtpq0"
+		id, err := user.ParseID(idStr)
+		if err != nil {
+			t.Fatalf("xid.FromString(%s) err = %v", idStr, err)
+		}
+
+		got := id.String()
+		if got != idStr {
+			t.Errorf("ID.String() = %s, want %s", got, idStr)
+		}
+	}
+}

--- a/services/user-svc/domain/user/model.go
+++ b/services/user-svc/domain/user/model.go
@@ -3,12 +3,10 @@ package user
 import (
 	"net/mail"
 	"time"
-
-	"github.com/rs/xid"
 )
 
 type User struct {
-	ID          xid.ID
+	ID          ID
 	Email       mail.Address
 	DateCreated time.Time
 	DateUpdated time.Time

--- a/services/user-svc/domain/user/repository.go
+++ b/services/user-svc/domain/user/repository.go
@@ -3,8 +3,6 @@ package user
 import (
 	"context"
 	"net/mail"
-
-	"github.com/rs/xid"
 )
 
 // Repository interface declares the behavior this package needs to perists and
@@ -12,11 +10,11 @@ import (
 type Repository interface {
 	// Delete removes the user with the given id and returns
 	// the deleted user, or an error if the user was not found.
-	Delete(ctx context.Context, id xid.ID) (User, error)
+	Delete(ctx context.Context, id ID) (User, error)
 
 	// FindByID returns the user with the given id, or an error
 	// if the user was not found.
-	FindByID(ctx context.Context, id xid.ID) (User, error)
+	FindByID(ctx context.Context, id ID) (User, error)
 
 	// FindByEmail returns the user with the given email, or an error
 	// if the user was not found.

--- a/services/user-svc/domain/user/testing/repository.go
+++ b/services/user-svc/domain/user/testing/repository.go
@@ -9,7 +9,6 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hausops/mono/services/user-svc/domain/user"
-	"github.com/rs/xid"
 )
 
 // TestRepository is a suite of unit tests that ensure
@@ -29,7 +28,7 @@ func TestRepository(t *testing.T, newRepo func(t *testing.T) user.Repository) {
 		mustRepositoryUpsertMany(t, ctx, repo, uu)
 
 		// Delete a user that does not exist.
-		_, err := repo.Delete(ctx, xid.New())
+		_, err := repo.Delete(ctx, user.NewID())
 		if err != user.ErrNotFound {
 			t.Error("Deleted user that does not exist")
 		}
@@ -74,7 +73,7 @@ func TestRepository(t *testing.T, newRepo func(t *testing.T) user.Repository) {
 		uu := generateTestUsers(t, 3)
 		mustRepositoryUpsertMany(t, ctx, repo, uu)
 
-		_, err := repo.FindByID(ctx, xid.New())
+		_, err := repo.FindByID(ctx, user.NewID())
 		if err != user.ErrNotFound {
 			t.Errorf("FindByID(randomID) error = %v, want: ErrNotFound", err)
 		}
@@ -115,7 +114,7 @@ func TestRepository(t *testing.T, newRepo func(t *testing.T) user.Repository) {
 		t.Run("Insert a new user", func(t *testing.T) {
 			repo := newRepo(t)
 			u := user.User{
-				ID:    xid.New(),
+				ID:    user.NewID(),
 				Email: mail.Address{Address: gofakeit.Email()},
 			}
 
@@ -153,7 +152,7 @@ func TestRepository(t *testing.T, newRepo func(t *testing.T) user.Repository) {
 		t.Run("Update with the same user info", func(t *testing.T) {
 			repo := newRepo(t)
 			u := user.User{
-				ID:    xid.New(),
+				ID:    user.NewID(),
 				Email: mail.Address{Address: gofakeit.Email()},
 			}
 			mustRepositoryUpsert(t, ctx, repo, u)
@@ -170,13 +169,13 @@ func TestRepository(t *testing.T, newRepo func(t *testing.T) user.Repository) {
 		t.Run("Insert a new user with a duplicate email", func(t *testing.T) {
 			repo := newRepo(t)
 			u := user.User{
-				ID:    xid.New(),
+				ID:    user.NewID(),
 				Email: mail.Address{Address: gofakeit.Email()},
 			}
 			mustRepositoryUpsert(t, ctx, repo, u)
 
 			_, err := repo.Upsert(ctx, user.User{
-				ID:    xid.New(),
+				ID:    user.NewID(),
 				Email: u.Email,
 			})
 			if !errors.Is(err, user.ErrEmailTaken) {
@@ -205,7 +204,7 @@ func TestRepository(t *testing.T, newRepo func(t *testing.T) user.Repository) {
 		t.Run("Update an existing user with a different email", func(t *testing.T) {
 			repo := newRepo(t)
 			u := user.User{
-				ID:    xid.New(),
+				ID:    user.NewID(),
 				Email: mail.Address{Address: gofakeit.Email()},
 			}
 			mustRepositoryUpsert(t, ctx, repo, u)

--- a/services/user-svc/domain/user/testing/testing.go
+++ b/services/user-svc/domain/user/testing/testing.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/hausops/mono/services/user-svc/domain/user"
-	"github.com/rs/xid"
 )
 
 func generateTestUsers(t *testing.T, count int) []user.User {
@@ -15,7 +14,7 @@ func generateTestUsers(t *testing.T, count int) []user.User {
 	uu := make([]user.User, count)
 	for i := 0; i < len(uu); i++ {
 		uu[i] = user.User{
-			ID:    xid.New(),
+			ID:    user.NewID(),
 			Email: mail.Address{Address: gofakeit.Email()},
 		}
 	}

--- a/services/user-svc/grpcserver/internal/user/user.go
+++ b/services/user-svc/grpcserver/internal/user/user.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hausops/mono/services/user-svc/domain/user"
 	"github.com/hausops/mono/services/user-svc/pb"
-	"github.com/rs/xid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -31,7 +30,7 @@ func (s *server) Create(ctx context.Context, in *pb.EmailRequest) (*pb.User, err
 
 	now := time.Now().UTC()
 	u := user.User{
-		ID:          xid.New(),
+		ID:          user.NewID(),
 		Email:       *email,
 		DateCreated: now,
 		DateUpdated: now,

--- a/services/user-svc/grpcserver/internal/user/user_test.go
+++ b/services/user-svc/grpcserver/internal/user/user_test.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/hausops/mono/services/user-svc/adapter/local"
-	"github.com/hausops/mono/services/user-svc/grpcserver/internal/user"
+	"github.com/hausops/mono/services/user-svc/domain/user"
+	usergrpc "github.com/hausops/mono/services/user-svc/grpcserver/internal/user"
 	"github.com/hausops/mono/services/user-svc/pb"
-	"github.com/rs/xid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func TestCreate(t *testing.T) {
-	svc := user.NewServer(local.NewUserRepository())
+	svc := usergrpc.NewServer(local.NewUserRepository())
 
 	email := gofakeit.Email()
 	req := &pb.EmailRequest{Email: email}
@@ -24,7 +24,7 @@ func TestCreate(t *testing.T) {
 		t.Errorf("Create(%s) error = %v", email, err)
 	}
 
-	if _, err := xid.FromString(u.Id); err != nil {
+	if _, err := user.ParseID(u.Id); err != nil {
 		t.Errorf("Id is invalid: %v", err)
 	}
 
@@ -42,7 +42,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreate_InvalidEmail(t *testing.T) {
-	svc := user.NewServer(local.NewUserRepository())
+	svc := usergrpc.NewServer(local.NewUserRepository())
 
 	for _, email := range []string{"", "invalid-email"} {
 		req := &pb.EmailRequest{Email: email}
@@ -62,7 +62,7 @@ func TestCreate_InvalidEmail(t *testing.T) {
 }
 
 func TestCreate_EmailTaken(t *testing.T) {
-	svc := user.NewServer(local.NewUserRepository())
+	svc := usergrpc.NewServer(local.NewUserRepository())
 	u := mustCreateUser(t, svc)
 
 	req := &pb.EmailRequest{Email: u.Email}
@@ -81,7 +81,7 @@ func TestCreate_EmailTaken(t *testing.T) {
 }
 
 func TestFindByEmail(t *testing.T) {
-	svc := user.NewServer(local.NewUserRepository())
+	svc := usergrpc.NewServer(local.NewUserRepository())
 	u := mustCreateUser(t, svc)
 
 	req := &pb.EmailRequest{Email: u.Email}
@@ -99,7 +99,7 @@ func TestFindByEmail(t *testing.T) {
 }
 
 func TestFindByEmail_InvalidEmail(t *testing.T) {
-	svc := user.NewServer(local.NewUserRepository())
+	svc := usergrpc.NewServer(local.NewUserRepository())
 	mustCreateUser(t, svc)
 
 	email := "invalid-email"
@@ -116,7 +116,7 @@ func TestFindByEmail_InvalidEmail(t *testing.T) {
 }
 
 func TestFindByEmail_NotFound(t *testing.T) {
-	svc := user.NewServer(local.NewUserRepository())
+	svc := usergrpc.NewServer(local.NewUserRepository())
 	mustCreateUser(t, svc)
 
 	email := "non-existing-email@hausops.com"


### PR DESCRIPTION
Create `user.ID` type based on `xid.ID` with a function to parse it from string, so other services can use `user.ID` instead of `string` when refer to user ID.