### PR TITLE
[user-svc] Provide mock UserServiceClient (gRPC)

### DIFF
--- a/services/user-svc/adapter/local/local.go
+++ b/services/user-svc/adapter/local/local.go
@@ -1,2 +1,0 @@
-// Package local implements domain components in memory for using locally.
-package local

--- a/services/user-svc/adapter/mock/mock.go
+++ b/services/user-svc/adapter/mock/mock.go
@@ -1,0 +1,3 @@
+// Package mock implements domain components in memory for demo
+// and testing purposes.
+package mock

--- a/services/user-svc/adapter/mock/user.go
+++ b/services/user-svc/adapter/mock/user.go
@@ -1,4 +1,4 @@
-package local
+package mock
 
 import (
 	"context"

--- a/services/user-svc/adapter/mock/user_test.go
+++ b/services/user-svc/adapter/mock/user_test.go
@@ -1,15 +1,15 @@
-package local_test
+package mock_test
 
 import (
 	"testing"
 
-	"github.com/hausops/mono/services/user-svc/adapter/local"
+	"github.com/hausops/mono/services/user-svc/adapter/mock"
 	"github.com/hausops/mono/services/user-svc/domain/user"
 	usertesting "github.com/hausops/mono/services/user-svc/domain/user/testing"
 )
 
 func TestUserRepository(t *testing.T) {
 	usertesting.TestRepository(t, func(_ *testing.T) user.Repository {
-		return local.NewUserRepository()
+		return mock.NewUserRepository()
 	})
 }

--- a/services/user-svc/config/config.go
+++ b/services/user-svc/config/config.go
@@ -29,8 +29,8 @@ func (c *Config) UnmarshalYAML(node *yaml.Node) error {
 
 	// Set datastore
 	switch kind := conf.Datastore["kind"].Value; kind {
-	case "local":
-		c.Datastore = LocalDatastore{}
+	case "mock":
+		c.Datastore = MockDatastore{}
 	case "mongo":
 		var mongo MongoDatastore
 		spec := conf.Datastore["spec"]
@@ -57,7 +57,7 @@ func (c *Config) Validate() error {
 	}
 
 	switch t := c.Datastore.(type) {
-	case LocalDatastore:
+	case MockDatastore:
 	case MongoDatastore:
 		if t.URI == "" {
 			return errors.New("mongo datastore missing URI field")
@@ -106,9 +106,9 @@ type datastore interface {
 	isDatastore()
 }
 
-type LocalDatastore struct{}
+type MockDatastore struct{}
 
-func (d LocalDatastore) isDatastore() {}
+func (d MockDatastore) isDatastore() {}
 
 type MongoDatastore struct {
 	// URI is the mongo connection URI.

--- a/services/user-svc/config/config_test.go
+++ b/services/user-svc/config/config_test.go
@@ -59,7 +59,7 @@ func TestConfig_Validate(t *testing.T) {
 			name: "valid configuration",
 			config: config.Config{
 				Mode:      config.ModeProd,
-				Datastore: config.LocalDatastore{},
+				Datastore: config.MockDatastore{},
 			},
 			wantErr: false,
 		},
@@ -67,7 +67,7 @@ func TestConfig_Validate(t *testing.T) {
 			name: "invalid mode",
 			config: config.Config{
 				Mode:      "invalid",
-				Datastore: config.LocalDatastore{},
+				Datastore: config.MockDatastore{},
 			},
 			wantErr: true,
 		},

--- a/services/user-svc/domain/user/id_test.go
+++ b/services/user-svc/domain/user/id_test.go
@@ -91,7 +91,7 @@ func TestID_String(t *testing.T) {
 		idStr := "cio035jjtoj2i2fbtpq0"
 		id, err := user.ParseID(idStr)
 		if err != nil {
-			t.Fatalf("xid.FromString(%s) err = %v", idStr, err)
+			t.Fatalf("user.ParseID(%s) err = %v", idStr, err)
 		}
 
 		got := id.String()

--- a/services/user-svc/etc/config.example.yaml
+++ b/services/user-svc/etc/config.example.yaml
@@ -1,6 +1,6 @@
 mode: dev
 datastore:
-  # kind: local
+  # kind: mock
   kind: mongo
   spec:
     uri: mongodb://localhost:27017

--- a/services/user-svc/grpcserver/dependencies.go
+++ b/services/user-svc/grpcserver/dependencies.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hausops/mono/services/user-svc/adapter/local"
+	"github.com/hausops/mono/services/user-svc/adapter/mock"
 	"github.com/hausops/mono/services/user-svc/adapter/mongo"
 	"github.com/hausops/mono/services/user-svc/config"
 	"github.com/hausops/mono/services/user-svc/domain/user"
@@ -21,8 +21,8 @@ type dependencies struct {
 func newDependencies(ctx context.Context, conf config.Config) (*dependencies, error) {
 	var deps dependencies
 	switch t := conf.Datastore.(type) {
-	case config.LocalDatastore:
-		deps.userRepo = local.NewUserRepository()
+	case config.MockDatastore:
+		deps.userRepo = mock.NewUserRepository()
 
 	case config.MongoDatastore:
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/services/user-svc/grpcserver/grpcserver.go
+++ b/services/user-svc/grpcserver/grpcserver.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	"github.com/hausops/mono/services/user-svc/config"
-	"github.com/hausops/mono/services/user-svc/grpcserver/internal/user"
 	"github.com/hausops/mono/services/user-svc/pb"
 )
 
@@ -36,7 +35,7 @@ func New(ctx context.Context, conf config.Config, logger *zap.Logger) (*server, 
 		return nil, fmt.Errorf("new dependencies: %w", err)
 	}
 
-	pb.RegisterUserServiceServer(srv, user.NewServer(deps.userRepo))
+	pb.RegisterUserServiceServer(srv, NewUserServer(deps.userRepo))
 
 	if conf.Mode == config.ModeDev {
 		reflection.Register(srv)

--- a/services/user-svc/grpcserver/mock/mock.go
+++ b/services/user-svc/grpcserver/mock/mock.go
@@ -1,0 +1,2 @@
+// Package mock provides the mock gRPC server for the service.
+package mock

--- a/services/user-svc/grpcserver/mock/user.go
+++ b/services/user-svc/grpcserver/mock/user.go
@@ -1,0 +1,40 @@
+package mock
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hausops/mono/services/user-svc/adapter/mock"
+	"github.com/hausops/mono/services/user-svc/grpcserver"
+	"github.com/hausops/mono/services/user-svc/pb"
+	"google.golang.org/grpc"
+)
+
+// userServiceClient implements pb.UserServiceClient as a mock so services
+// depending on user-svc can use it as a test client in tests.
+type userServiceClient struct {
+	server pb.UserServiceServer
+}
+
+// NewUserServiceClient creates a userServiceClient using mock user.Repository.
+func NewUserServiceClient() *userServiceClient {
+	repo := mock.NewUserRepository()
+	server := grpcserver.NewUserServer(repo)
+	return &userServiceClient{server: server}
+}
+
+var _ pb.UserServiceClient = (*userServiceClient)(nil)
+
+func (c *userServiceClient) Create(ctx context.Context, in *pb.EmailRequest, opts ...grpc.CallOption) (*pb.User, error) {
+	if len(opts) > 0 {
+		return nil, errors.New("mock.UserServiceClient does not support grpc.CallOption")
+	}
+	return c.server.Create(ctx, in)
+}
+
+func (c *userServiceClient) FindByEmail(ctx context.Context, in *pb.EmailRequest, opts ...grpc.CallOption) (*pb.User, error) {
+	if len(opts) > 0 {
+		return nil, errors.New("mock.UserServiceClient does not support grpc.CallOption")
+	}
+	return c.server.FindByEmail(ctx, in)
+}

--- a/services/user-svc/grpcserver/user.go
+++ b/services/user-svc/grpcserver/user.go
@@ -1,4 +1,4 @@
-package user
+package grpcserver
 
 import (
 	"context"
@@ -13,16 +13,16 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type server struct {
+type userServer struct {
 	pb.UnimplementedUserServiceServer
 	repo user.Repository
 }
 
-func NewServer(repo user.Repository) *server {
-	return &server{repo: repo}
+func NewUserServer(repo user.Repository) *userServer {
+	return &userServer{repo: repo}
 }
 
-func (s *server) Create(ctx context.Context, in *pb.EmailRequest) (*pb.User, error) {
+func (s *userServer) Create(ctx context.Context, in *pb.EmailRequest) (*pb.User, error) {
 	email, err := mail.ParseAddress(in.Email)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "Invalid email address")
@@ -48,7 +48,7 @@ func (s *server) Create(ctx context.Context, in *pb.EmailRequest) (*pb.User, err
 	return encodeUser(created), nil
 }
 
-func (s *server) FindByEmail(ctx context.Context, in *pb.EmailRequest) (*pb.User, error) {
+func (s *userServer) FindByEmail(ctx context.Context, in *pb.EmailRequest) (*pb.User, error) {
 	email, err := mail.ParseAddress(in.Email)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "Invalid email address")

--- a/services/user-svc/grpcserver/user_test.go
+++ b/services/user-svc/grpcserver/user_test.go
@@ -1,20 +1,20 @@
-package user_test
+package grpcserver_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"github.com/hausops/mono/services/user-svc/adapter/local"
+	"github.com/hausops/mono/services/user-svc/adapter/mock"
 	"github.com/hausops/mono/services/user-svc/domain/user"
-	usergrpc "github.com/hausops/mono/services/user-svc/grpcserver/internal/user"
+	"github.com/hausops/mono/services/user-svc/grpcserver"
 	"github.com/hausops/mono/services/user-svc/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func TestCreate(t *testing.T) {
-	svc := usergrpc.NewServer(local.NewUserRepository())
+	svc := grpcserver.NewUserServer(mock.NewUserRepository())
 
 	email := gofakeit.Email()
 	req := &pb.EmailRequest{Email: email}
@@ -42,7 +42,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreate_InvalidEmail(t *testing.T) {
-	svc := usergrpc.NewServer(local.NewUserRepository())
+	svc := grpcserver.NewUserServer(mock.NewUserRepository())
 
 	for _, email := range []string{"", "invalid-email"} {
 		req := &pb.EmailRequest{Email: email}
@@ -62,7 +62,7 @@ func TestCreate_InvalidEmail(t *testing.T) {
 }
 
 func TestCreate_EmailTaken(t *testing.T) {
-	svc := usergrpc.NewServer(local.NewUserRepository())
+	svc := grpcserver.NewUserServer(mock.NewUserRepository())
 	u := mustCreateUser(t, svc)
 
 	req := &pb.EmailRequest{Email: u.Email}
@@ -81,7 +81,7 @@ func TestCreate_EmailTaken(t *testing.T) {
 }
 
 func TestFindByEmail(t *testing.T) {
-	svc := usergrpc.NewServer(local.NewUserRepository())
+	svc := grpcserver.NewUserServer(mock.NewUserRepository())
 	u := mustCreateUser(t, svc)
 
 	req := &pb.EmailRequest{Email: u.Email}
@@ -99,7 +99,7 @@ func TestFindByEmail(t *testing.T) {
 }
 
 func TestFindByEmail_InvalidEmail(t *testing.T) {
-	svc := usergrpc.NewServer(local.NewUserRepository())
+	svc := grpcserver.NewUserServer(mock.NewUserRepository())
 	mustCreateUser(t, svc)
 
 	email := "invalid-email"
@@ -116,7 +116,7 @@ func TestFindByEmail_InvalidEmail(t *testing.T) {
 }
 
 func TestFindByEmail_NotFound(t *testing.T) {
-	svc := usergrpc.NewServer(local.NewUserRepository())
+	svc := grpcserver.NewUserServer(mock.NewUserRepository())
 	mustCreateUser(t, svc)
 
 	email := "non-existing-email@hausops.com"


### PR DESCRIPTION
- create `grpcserver/mock` providing `userServiceClient` to be used by client services like `auth-svc`
- rename `adapter/local` -> `adapter/mock`