### PR TITLE
[dashboard] Use prettier v3 default trailing comma (all)

### DIFF
--- a/apps/dashboard/.prettierrc.yaml
+++ b/apps/dashboard/.prettierrc.yaml
@@ -1,4 +1,2 @@
 bracketSpacing: false
 singleQuote: true
-# Backward compatible with prettier v2
-trailingComma: es5

--- a/apps/dashboard/components/AddressForm.css.ts
+++ b/apps/dashboard/components/AddressForm.css.ts
@@ -7,7 +7,7 @@ export const layout = styleVariants({
     gap: unit(4),
   },
 
-  foutColumns: {
+  fourColumns: {
     display: 'grid',
     gap: unit(4),
 

--- a/apps/dashboard/components/AddressForm.tsx
+++ b/apps/dashboard/components/AddressForm.tsx
@@ -28,7 +28,7 @@ export function AddressForm({
   const cs =
     layout === 'full-width'
       ? {
-          root: s.layout.foutColumns,
+          root: s.layout.fourColumns,
           line1: s.gridColumnSpan[2],
           line2: s.gridColumnSpan[2],
           city: s.gridColumnSpan[2],
@@ -69,7 +69,7 @@ export function AddressForm({
         name={`${namePrefix}AddressState`}
         options={useMemo(
           () => addressSvc.getAllStates().map((s) => toOption(s.code)),
-          [addressSvc]
+          [addressSvc],
         )}
         value={fields.state}
         onChange={(e) => updateField('state', e.target.value)}
@@ -86,7 +86,7 @@ export function AddressForm({
 }
 
 export function useAddressFormState(
-  initialState?: AddressModel
+  initialState?: AddressModel,
 ): AddressFormState {
   return useFieldsState({
     line1: '',

--- a/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
@@ -56,7 +56,7 @@ function PropertyTypeOption({state, ...props}: PropertyTypeOptionProps) {
   const {clickableZoneProps, inputProps, isSelected} = useRadio(
     props,
     state,
-    ref
+    ref,
   );
   const {isFocusVisible, focusProps} = useFocusRing();
 

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/MultiFamilyPropertyDetails.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/MultiFamilyPropertyDetails.tsx
@@ -10,7 +10,7 @@ type MultiFamilyPropertyDetailsProps = {
 };
 
 export function MultiFamilyPropertyDetails(
-  props: MultiFamilyPropertyDetailsProps
+  props: MultiFamilyPropertyDetailsProps,
 ) {
   const {property} = props;
   return (

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/PropertyInfo.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/PropertyInfo.tsx
@@ -23,7 +23,7 @@ export function PropertyInfo(props: PropertyInfoProps) {
     async () => {
       const p = await propertySvc.getById(props.property.id);
       return p?.type === 'multi-family' ? p : undefined;
-    }
+    },
   );
   const property = data ?? props.property;
 
@@ -113,7 +113,7 @@ function Editing({
 }
 
 function toPropertyModel(
-  address: AddressFormState['fields']
+  address: AddressFormState['fields'],
 ): Partial<MultiFamily.Property> {
   return {address};
 }

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/Unit.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/Unit.tsx
@@ -72,7 +72,7 @@ function Rented(props: RentedProps) {
   const {pastPayments, upcomingRent} = lease;
   const overdue = useMemo(
     () => pastPayments.find((p) => p.status === 'overdue'),
-    [pastPayments]
+    [pastPayments],
   );
   return (
     <>

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/UnitList.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/UnitList.tsx
@@ -17,7 +17,7 @@ export function UnitList(props: UnitListProps) {
       const unitIds = property.units.map((u) => u.id).sort();
       const leases = await leaseSvc.getManyByUnitIds(unitIds);
       return new Map(leases.map((lease) => [lease.unitId, lease]));
-    }
+    },
   );
 
   if (isLoading) {

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/PropertyInfo.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/PropertyInfo.tsx
@@ -27,7 +27,7 @@ export function PropertyInfo(props: PropertyInfoProps) {
     async () => {
       const p = await propertySvc.getById(props.property.id);
       return p?.type === 'single-family' ? p : undefined;
-    }
+    },
   );
   const property = data ?? props.property;
 
@@ -176,7 +176,7 @@ function Editing({
 
 function toPropertyModel(
   address: AddressFormState['fields'],
-  unit: UnitFields
+  unit: UnitFields,
 ): Partial<SingleFamily.Property> {
   return {
     address,

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RecentPayments.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RecentPayments.tsx
@@ -15,7 +15,7 @@ export function RecentPayments({payments}: RecentPaymentsProps) {
         currency: 'USD',
         maximumSignificantDigits: 2,
       }),
-    []
+    [],
   );
 
   return (

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RentInfo.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RentInfo.tsx
@@ -19,7 +19,7 @@ export function RentInfo({property}: RentInfoProps) {
   const leaseSvc = useLeaseService();
   const unitId = property.unit.id;
   const {isLoading, data} = useSWR(`lease.unit-${unitId}`, () =>
-    leaseSvc.getByUnitId(unitId)
+    leaseSvc.getByUnitId(unitId),
   );
 
   if (isLoading) {

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/UpcomingRent.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/UpcomingRent.tsx
@@ -20,7 +20,7 @@ export function UpcomingRent({
         currency: 'USD',
         maximumSignificantDigits: 2,
       }),
-    []
+    [],
   );
 
   return (

--- a/apps/dashboard/components/PropertyForm.tsx
+++ b/apps/dashboard/components/PropertyForm.tsx
@@ -8,7 +8,7 @@ type Props = {
 export function BedroomsSelect({value, onChange}: Props) {
   const options = useMemo(
     () => [{label: 'Studio', value: 0}, ...[1, 2, 3, 4, 5].map(toOption)],
-    []
+    [],
   );
 
   return (
@@ -30,7 +30,7 @@ export function BathroomsSelect({value, onChange}: Props) {
       {label: 'None', value: 0},
       ...[1, 1.5, 2, 2.5, 3, 3.5, 4].map(toOption),
     ],
-    []
+    [],
   );
   return (
     <Select

--- a/apps/dashboard/components/useFieldsState.ts
+++ b/apps/dashboard/components/useFieldsState.ts
@@ -8,7 +8,7 @@ export type FieldsState<T> = {
 export function useFieldsState<T>(initialFields: T): FieldsState<T> {
   const [fields, dispatch] = useReducer<Reducer<T, Action<T>>>(
     fieldsReducer,
-    initialFields
+    initialFields,
   );
 
   return {

--- a/apps/dashboard/pages/properties/[id].tsx
+++ b/apps/dashboard/pages/properties/[id].tsx
@@ -22,7 +22,7 @@ export default function Page() {
     `/api/properties/${propertyId}`,
     () =>
       // this is undefined during SSR
-      typeof propertyId === 'string' ? propertySvc.getById(propertyId) : null
+      typeof propertyId === 'string' ? propertySvc.getById(propertyId) : null,
   );
 
   if (isLoading) {

--- a/apps/dashboard/pages/properties/new.tsx
+++ b/apps/dashboard/pages/properties/new.tsx
@@ -78,7 +78,7 @@ export default function Page() {
 
 function toNewPropertyData(
   address: AddressFormState['fields'],
-  details: DetailsFormState
+  details: DetailsFormState,
 ): NewPropertyData {
   // TODO: validate required
   const propertyType = details.propertyType.selectedValue ?? 'single-family';

--- a/apps/dashboard/services/lease/LocalLeaseService.ts
+++ b/apps/dashboard/services/lease/LocalLeaseService.ts
@@ -3,7 +3,7 @@ import {LeaseService} from './LeaseService';
 
 export class LocalLeaseService implements LeaseService {
   private readonly byUnitId = new Map<string, LeaseModel>(
-    DEMO_LEASES.map((lease) => [lease.unitId, lease])
+    DEMO_LEASES.map((lease) => [lease.unitId, lease]),
   );
 
   async getByUnitId(unitId: string) {

--- a/apps/dashboard/services/property/LocalPropertyService.ts
+++ b/apps/dashboard/services/property/LocalPropertyService.ts
@@ -4,7 +4,7 @@ import {PropertyNotFoundErr, PropertyService} from './PropertyService';
 
 export class LocalPropertyService implements PropertyService {
   private readonly properties: Map<string, PropertyModel> = new Map(
-    DEMO_PROPERTIES.map((p) => [p.id, p])
+    DEMO_PROPERTIES.map((p) => [p.id, p]),
   );
 
   async getAll(): Promise<PropertyModel[]> {
@@ -27,7 +27,7 @@ export class LocalPropertyService implements PropertyService {
 
   async update<T extends PropertyModel>(
     id: string,
-    updateProperty: Partial<T>
+    updateProperty: Partial<T>,
   ): Promise<T> {
     const previous = this.properties.get(id);
 
@@ -37,7 +37,7 @@ export class LocalPropertyService implements PropertyService {
 
     if (updateProperty.type && updateProperty.type !== previous.type) {
       throw new Error(
-        `Mismatched property type: was=${previous.type}, got=${updateProperty.type}.`
+        `Mismatched property type: was=${previous.type}, got=${updateProperty.type}.`,
       );
     }
 

--- a/apps/dashboard/services/property/PropertyService.ts
+++ b/apps/dashboard/services/property/PropertyService.ts
@@ -14,7 +14,7 @@ export interface PropertyService {
   // If a property with the id is not found, it will reject with an error.
   update<T extends PropertyModel>(
     id: string,
-    updateProperty: Partial<T>
+    updateProperty: Partial<T>,
   ): Promise<T>;
 
   // deletes the property matching id.

--- a/apps/dashboard/volto/AspectRatio.css.ts
+++ b/apps/dashboard/volto/AspectRatio.css.ts
@@ -13,5 +13,5 @@ export const ratio = styleVariants(
     '4:3': '4 / 3',
     '16:9': '16 / 9',
   },
-  (r) => [root, {aspectRatio: r}]
+  (r) => [root, {aspectRatio: r}],
 );

--- a/apps/dashboard/volto/Badge.css.ts
+++ b/apps/dashboard/volto/Badge.css.ts
@@ -53,5 +53,5 @@ export const LivenessBadgeStatus = styleVariants(
       height: unit(2),
       width: unit(2),
     },
-  })
+  }),
 );

--- a/apps/dashboard/volto/Radio/Radio.tsx
+++ b/apps/dashboard/volto/Radio/Radio.tsx
@@ -15,5 +15,5 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
         ref={ref}
       />
     );
-  }
+  },
 );

--- a/apps/dashboard/volto/Radio/useRadio.ts
+++ b/apps/dashboard/volto/Radio/useRadio.ts
@@ -27,7 +27,7 @@ type Radio<T> = {
 export function useRadio<T extends string>(
   props: RadioProps<T>,
   state: RadioGroupState<T>,
-  ref: RefObject<HTMLInputElement>
+  ref: RefObject<HTMLInputElement>,
 ): Radio<T> {
   const {name, value, isDisabled = state.isDisabled} = props;
   const isSelected = state.selectedValue === value;

--- a/apps/dashboard/volto/Radio/useRadioGroupState.ts
+++ b/apps/dashboard/volto/Radio/useRadioGroupState.ts
@@ -17,7 +17,7 @@ export type RadioGroupState<T> = {
 };
 
 export function useRadioGroupState<T extends string>(
-  props: RadioGroupProps<T> = {}
+  props: RadioGroupProps<T> = {},
 ): RadioGroupState<T> {
   const {initialValue, isReadOnly = false, isDisabled = false} = props;
   const [selectedValue, setSelected] = useState<T | null>(initialValue ?? null);

--- a/apps/dashboard/volto/Select.tsx
+++ b/apps/dashboard/volto/Select.tsx
@@ -49,7 +49,7 @@ export function Select({
 }
 
 export function toOption<T extends number | string>(
-  value: T
+  value: T,
 ): {label: string; value: T} {
   return {label: `${value}`, value};
 }

--- a/apps/dashboard/volto/Tooltip/CopyToClipboardTooltip.tsx
+++ b/apps/dashboard/volto/Tooltip/CopyToClipboardTooltip.tsx
@@ -66,7 +66,7 @@ type CopyState = {
 
 export function useCopyToClipboardState(
   content: string,
-  tooltipState: TooltipState
+  tooltipState: TooltipState,
 ): CopyState {
   const [isCopied, setCopied] = useState(false);
   return {

--- a/apps/dashboard/volto/Tooltip/Tooltip.tsx
+++ b/apps/dashboard/volto/Tooltip/Tooltip.tsx
@@ -50,6 +50,6 @@ export function Tooltip(props: TooltipProps) {
     >
       {children}
     </div>,
-    portalsContainer
+    portalsContainer,
   );
 }

--- a/apps/dashboard/volto/Tooltip/TooltipsManager.tsx
+++ b/apps/dashboard/volto/Tooltip/TooltipsManager.tsx
@@ -24,7 +24,7 @@ export function TooltipsManagerProvider(props: TooltipsManagerProviderProps) {
   // Cannot use useRef here because it does not cause a re-render
   // thus the context is not updated after the container mounted.
   const [portalsContainer, setPortalsContainer] = useState<HTMLElement | null>(
-    null
+    null,
   );
 
   const {current: visibility} = useRef(new VisibilityManager());
@@ -76,5 +76,5 @@ const PortalsContainer = forwardRef<HTMLDivElement>(
     return (
       <div id="tooltips-container" className={s.PortalsContainer} ref={ref} />
     );
-  }
+  },
 );

--- a/apps/dashboard/volto/Tooltip/useTooltipState.ts
+++ b/apps/dashboard/volto/Tooltip/useTooltipState.ts
@@ -10,7 +10,7 @@ export type TooltipState = {
 export function useTooltipState(
   // id is used to identify the tooltip with the TooltipsManager
   id: string,
-  initialOpen: boolean = false
+  initialOpen: boolean = false,
 ): TooltipState {
   const [isOpen, setOpen] = useState(initialOpen);
   const {visibility} = useTooltipsManager();
@@ -30,7 +30,7 @@ export function useTooltipState(
     () => () => {
       visibility.deregisterCloseTooltip(id);
     },
-    [id, visibility]
+    [id, visibility],
   );
 
   return {


### PR DESCRIPTION
The default trailing comma is changed to `"all"` in Prettier v3. https://prettier.io/blog/2023/07/05/3.0.0.html
This PR switch to the new default and runs prettier on all files.