### PR TITLE
[dashboard] Update tsconfig per typescript v5 upgrade

### DIFF
--- a/apps/dashboard/components/AddressForm.tsx
+++ b/apps/dashboard/components/AddressForm.tsx
@@ -1,5 +1,5 @@
-import {FieldsState, useFieldsState} from '@/components/useFieldsState';
-import {AddressModel, useAddressService} from '@/services/address';
+import {useFieldsState, type FieldsState} from '@/components/useFieldsState';
+import {useAddressService, type AddressModel} from '@/services/address';
 import {Select, toOption} from '@/volto/Select';
 import {TextField} from '@/volto/TextField';
 import {useMemo} from 'react';

--- a/apps/dashboard/components/AppShell/AppShell.tsx
+++ b/apps/dashboard/components/AppShell/AppShell.tsx
@@ -1,8 +1,8 @@
-import {PropsWithChildren} from 'react';
+import type {PropsWithChildren} from 'react';
 import * as s from './AppShell.css';
 import {MainNav} from './MainNav';
 
-export function AppShell({children}: PropsWithChildren<{}>) {
+export function AppShell({children}: PropsWithChildren) {
   return (
     <div className={s.AppShell}>
       <MainNav />

--- a/apps/dashboard/components/AppShell/MainNav.tsx
+++ b/apps/dashboard/components/AppShell/MainNav.tsx
@@ -8,9 +8,9 @@ import {
   SettingsIcon,
   SpaceDashboardIcon,
 } from '@/volto/icons';
-import {PropsWithChildren} from 'react';
+import type {PropsWithChildren} from 'react';
 import * as s from './MainNav.css';
-import {NavLink, NavLinkProps} from './NavLink';
+import {NavLink, type NavLinkProps} from './NavLink';
 
 export function MainNav() {
   return (

--- a/apps/dashboard/components/AppShell/NavLink.tsx
+++ b/apps/dashboard/components/AppShell/NavLink.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
-import {ComponentType} from 'react';
+import type {ComponentType} from 'react';
 import * as s from './NavLink.css';
 
 export type NavLinkProps = {

--- a/apps/dashboard/components/AttributeList.tsx
+++ b/apps/dashboard/components/AttributeList.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {PropsWithChildren, ReactNode} from 'react';
+import type {PropsWithChildren, ReactNode} from 'react';
 import * as s from './AttributeList.css';
 
 export function AttributeList({

--- a/apps/dashboard/components/NewProperty/DetailsForm/DetailsForm.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/DetailsForm.tsx
@@ -1,18 +1,18 @@
-import {PropertyType} from '@/services/property';
-import {RadioGroupState, useRadioGroupState} from '@/volto/Radio';
+import type {PropertyType} from '@/services/property';
+import {useRadioGroupState, type RadioGroupState} from '@/volto/Radio';
 import {Section} from '@/volto/Section';
 import {PropertyTypeSelector} from './PropertyTypeSelector';
 
 import {
   SingleFamilyForm,
-  SingleFamilyFormState,
   useSingleFamilyFormState,
+  type SingleFamilyFormState,
 } from './SingleFamilyForm';
 
 import {
   MultiFamilyForm,
-  MultiFamilyFormState,
   useMultiFamilyFormState,
+  type MultiFamilyFormState,
 } from './MultiFamilyForm/MultiFamilyForm';
 
 export type DetailsFormState = {

--- a/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/MultiFamilyForm.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/MultiFamilyForm.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@/volto/Button';
 import {useReducer} from 'react';
 import * as s from './MultiFamilyForm.css';
-import {RentalUnit} from './RentalUnit';
+import type {RentalUnit} from './RentalUnit';
 import {UnitEntry} from './UnitEntry';
 
 export type MultiFamilyFormState = {

--- a/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/UnitEntry.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/MultiFamilyForm/UnitEntry.tsx
@@ -1,8 +1,8 @@
 import {BathroomsSelect, BedroomsSelect} from '@/components/PropertyForm';
 import {MiniTextButton} from '@/volto/Button';
-import {CloseIcon, CopyIcon} from '@/volto/icons';
 import {TextField} from '@/volto/TextField';
-import {RentalUnit} from './RentalUnit';
+import {CloseIcon, CopyIcon} from '@/volto/icons';
+import type {RentalUnit} from './RentalUnit';
 import * as s from './UnitEntry.css';
 
 type UnitEntryProps = {

--- a/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/PropertyTypeSelector.tsx
@@ -1,5 +1,10 @@
-import {PropertyType} from '@/services/property';
-import {Radio, RadioGroupState, useRadio, useRadioGroup} from '@/volto/Radio';
+import type {PropertyType} from '@/services/property';
+import {
+  Radio,
+  useRadio,
+  useRadioGroup,
+  type RadioGroupState,
+} from '@/volto/Radio';
 import {useFocusRing} from '@react-aria/focus';
 import clsx from 'clsx';
 import {useId, useRef} from 'react';

--- a/apps/dashboard/components/NewProperty/DetailsForm/SingleFamilyForm.tsx
+++ b/apps/dashboard/components/NewProperty/DetailsForm/SingleFamilyForm.tsx
@@ -1,5 +1,5 @@
 import {BathroomsSelect, BedroomsSelect} from '@/components/PropertyForm';
-import {FieldsState, useFieldsState} from '@/components/useFieldsState';
+import {useFieldsState, type FieldsState} from '@/components/useFieldsState';
 import {TextField} from '@/volto/TextField';
 import * as s from './SingleFamilyForm.css';
 

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/MultiFamilyPropertyDetails.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/MultiFamilyPropertyDetails.tsx
@@ -1,5 +1,5 @@
 import {PropertyImages} from '@/components/PropertyDetails/PropertyImages';
-import {MultiFamily} from '@/services/property';
+import type {MultiFamily} from '@/services/property';
 import {Section} from '@/volto/Section';
 import * as s from './MultiFamilyPropertyDetails.css';
 import {PropertyInfo} from './PropertyInfo';

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/PropertyInfo.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/PropertyInfo.tsx
@@ -1,13 +1,13 @@
 import {
   AddressForm,
-  AddressFormState,
   useAddressFormState,
+  type AddressFormState,
 } from '@/components/AddressForm';
 import {Address} from '@/services/address';
-import {MultiFamily, usePropertyService} from '@/services/property';
+import {usePropertyService, type MultiFamily} from '@/services/property';
 import {Button, MiniTextButton} from '@/volto/Button';
-import {CloseIcon, EditFilledIcon, LocationOnIcon} from '@/volto/icons';
 import {Section} from '@/volto/Section';
+import {CloseIcon, EditFilledIcon, LocationOnIcon} from '@/volto/icons';
 import {useState} from 'react';
 import useSWR from 'swr';
 import * as s from './PropertyInfo.css';

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/Unit.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/Unit.tsx
@@ -1,9 +1,9 @@
-import {LeaseModel} from '@/services/lease';
-import {MultiFamily} from '@/services/property';
+import type {LeaseModel} from '@/services/lease';
+import type {MultiFamily} from '@/services/property';
 import {Badge, LivenessBadge} from '@/volto/Badge';
 import {IconButton} from '@/volto/Button';
-import {MoreHIcon} from '@/volto/icons';
 import {TextSkeleton} from '@/volto/Skeleton';
+import {MoreHIcon} from '@/volto/icons';
 import Link from 'next/link';
 import {useMemo} from 'react';
 import * as s from './Unit.css';

--- a/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/UnitList.tsx
+++ b/apps/dashboard/components/PropertyDetails/MultiFamilyPropertyDetails/UnitList/UnitList.tsx
@@ -1,5 +1,5 @@
 import {useLeaseService} from '@/services/lease';
-import {MultiFamily} from '@/services/property';
+import type {MultiFamily} from '@/services/property';
 import useSWR from 'swr';
 import {Unit, UnitSkeleton} from './Unit';
 

--- a/apps/dashboard/components/PropertyDetails/PropertyDetails.tsx
+++ b/apps/dashboard/components/PropertyDetails/PropertyDetails.tsx
@@ -1,5 +1,5 @@
 import {LeaseServiceProvider, LocalLeaseService} from '@/services/lease';
-import {PropertyModel} from '@/services/property';
+import type {PropertyModel} from '@/services/property';
 import {MultiFamilyPropertyDetails} from './MultiFamilyPropertyDetails';
 import {SingleFamilyPropertyDetails} from './SingleFamilyPropertyDetails/SingleFamilyPropertyDetails';
 

--- a/apps/dashboard/components/PropertyDetails/PropertyImages.tsx
+++ b/apps/dashboard/components/PropertyDetails/PropertyImages.tsx
@@ -1,5 +1,5 @@
 import {Address} from '@/services/address';
-import {PropertyModel} from '@/services/property';
+import type {PropertyModel} from '@/services/property';
 import {AspectRatio} from '@/volto/AspectRatio';
 import {Section} from '@/volto/Section';
 import Image from 'next/image';

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/PropertyInfo.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/PropertyInfo.tsx
@@ -1,17 +1,17 @@
 import {
   AddressForm,
-  AddressFormState,
   useAddressFormState,
+  type AddressFormState,
 } from '@/components/AddressForm';
 import {Attribute, AttributeList} from '@/components/AttributeList';
 import {BathroomsSelect, BedroomsSelect} from '@/components/PropertyForm';
 import {useFieldsState} from '@/components/useFieldsState';
 import {Address} from '@/services/address';
-import {SingleFamily, usePropertyService} from '@/services/property';
+import {usePropertyService, type SingleFamily} from '@/services/property';
 import {Button, MiniTextButton} from '@/volto/Button';
-import {CloseIcon, EditFilledIcon} from '@/volto/icons';
 import {Section} from '@/volto/Section';
 import {TextField} from '@/volto/TextField';
+import {CloseIcon, EditFilledIcon} from '@/volto/icons';
 import {useState} from 'react';
 import useSWR from 'swr';
 import * as s from './PropertyInfo.css';

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RecentPayments.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RecentPayments.tsx
@@ -1,4 +1,4 @@
-import {RentPayment} from '@/services/lease';
+import type {RentPayment} from '@/services/lease';
 import {Badge} from '@/volto/Badge';
 import {useMemo} from 'react';
 import * as s from './RecentPayments.css';

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RentInfo.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/RentInfo.tsx
@@ -1,9 +1,9 @@
-import {LeaseModel, useLeaseService} from '@/services/lease';
-import {SingleFamily} from '@/services/property';
+import {useLeaseService, type LeaseModel} from '@/services/lease';
+import type {SingleFamily} from '@/services/property';
 import {Button} from '@/volto/Button';
 import {EmptyState} from '@/volto/EmptyState';
-import {HomeIcon} from '@/volto/icons';
 import {Section, SectionSkeleton} from '@/volto/Section';
+import {HomeIcon} from '@/volto/icons';
 import Link from 'next/link';
 import useSWR from 'swr';
 import {RecentPayments} from './RecentPayments';

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/UpcomingRent.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/RentInfo/UpcomingRent.tsx
@@ -1,5 +1,5 @@
 import {Attribute, AttributeList} from '@/components/AttributeList';
-import {RentPayment} from '@/services/lease';
+import type {RentPayment} from '@/services/lease';
 import {Badge} from '@/volto/Badge';
 import {useMemo} from 'react';
 import * as s from './UpcomingRent.css';

--- a/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/SingleFamilyPropertyDetails.tsx
+++ b/apps/dashboard/components/PropertyDetails/SingleFamilyPropertyDetails/SingleFamilyPropertyDetails.tsx
@@ -1,4 +1,4 @@
-import {SingleFamily} from '@/services/property';
+import type {SingleFamily} from '@/services/property';
 import {PropertyImages} from '../PropertyImages';
 import {PropertyInfo} from './PropertyInfo';
 import {RentInfo} from './RentInfo';

--- a/apps/dashboard/components/PropertyForm.tsx
+++ b/apps/dashboard/components/PropertyForm.tsx
@@ -1,5 +1,5 @@
 import {Select, toOption} from '@/volto/Select';
-import {ComponentPropsWithoutRef, useMemo} from 'react';
+import {useMemo, type ComponentPropsWithoutRef} from 'react';
 
 type Props = {
   onChange: (selection: number | undefined) => void;

--- a/apps/dashboard/components/PropertySummary/PropertySummary.tsx
+++ b/apps/dashboard/components/PropertySummary/PropertySummary.tsx
@@ -1,10 +1,10 @@
 import {Address} from '@/services/address';
-import {PropertyModel} from '@/services/property';
+import type {PropertyModel} from '@/services/property';
 import {AspectRatio} from '@/volto/AspectRatio';
 import {IconButton} from '@/volto/Button';
 import {Card} from '@/volto/Card';
-import {MoreHIcon} from '@/volto/icons';
 import {TextSkeleton} from '@/volto/Skeleton';
+import {MoreHIcon} from '@/volto/icons';
 import Image from 'next/image';
 import Link from 'next/link';
 import * as s from './PropertySummary.css';

--- a/apps/dashboard/components/useFieldsState.ts
+++ b/apps/dashboard/components/useFieldsState.ts
@@ -1,4 +1,4 @@
-import {Reducer, useCallback, useReducer} from 'react';
+import {useCallback, useReducer, type Reducer} from 'react';
 
 export type FieldsState<T> = {
   readonly fields: T;

--- a/apps/dashboard/layouts/Page.tsx
+++ b/apps/dashboard/layouts/Page.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as s from './Page.css';
 
 export function PageLayout({children}: {children: ReactNode}) {

--- a/apps/dashboard/layouts/PageHeader.tsx
+++ b/apps/dashboard/layouts/PageHeader.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as s from './PageHeader.css';
 
 type PageHeaderProps = {

--- a/apps/dashboard/pages/properties/new.tsx
+++ b/apps/dashboard/pages/properties/new.tsx
@@ -1,16 +1,16 @@
 import {
   AddressForm,
-  AddressFormState,
   useAddressFormState,
+  type AddressFormState,
 } from '@/components/AddressForm';
 import {
   DetailsForm,
-  DetailsFormState,
   useDetailsFormState,
+  type DetailsFormState,
 } from '@/components/NewProperty';
 import {PageLayout} from '@/layouts/Page';
 import {PageHeader} from '@/layouts/PageHeader';
-import {NewPropertyData, usePropertyService} from '@/services/property';
+import {usePropertyService, type NewPropertyData} from '@/services/property';
 import {Button} from '@/volto/Button';
 import {Section} from '@/volto/Section';
 import Head from 'next/head';

--- a/apps/dashboard/services/address/Address.ts
+++ b/apps/dashboard/services/address/Address.ts
@@ -1,4 +1,4 @@
-import {AddressModel} from './AddressModel';
+import type {AddressModel} from './AddressModel';
 
 export class Address {
   static from(model: AddressModel): Address {

--- a/apps/dashboard/services/address/AddressServiceContext.tsx
+++ b/apps/dashboard/services/address/AddressServiceContext.tsx
@@ -1,5 +1,5 @@
-import {createContext, PropsWithChildren, useContext} from 'react';
-import {AddressService} from './AddressService';
+import {createContext, useContext, type PropsWithChildren} from 'react';
+import type {AddressService} from './AddressService';
 
 export function AddressServiceProvider({
   service,

--- a/apps/dashboard/services/address/LocalAddressService.ts
+++ b/apps/dashboard/services/address/LocalAddressService.ts
@@ -1,4 +1,4 @@
-import {AddressService} from './AddressService';
+import type {AddressService} from './AddressService';
 import data from './data.local.json';
 
 // LocalAddressService keep data on the machine

--- a/apps/dashboard/services/lease/LeaseService.ts
+++ b/apps/dashboard/services/lease/LeaseService.ts
@@ -1,4 +1,4 @@
-import {LeaseModel} from './LeaseModel';
+import type {LeaseModel} from './LeaseModel';
 
 export interface LeaseService {
   getByUnitId(unitId: string): Promise<LeaseModel | undefined>;

--- a/apps/dashboard/services/lease/LeaseServiceContext.tsx
+++ b/apps/dashboard/services/lease/LeaseServiceContext.tsx
@@ -1,5 +1,5 @@
-import {createContext, PropsWithChildren, useContext} from 'react';
-import {LeaseService} from './LeaseService';
+import {createContext, useContext, type PropsWithChildren} from 'react';
+import type {LeaseService} from './LeaseService';
 
 export function LeaseServiceProvider({
   service,

--- a/apps/dashboard/services/lease/LocalLeaseService.ts
+++ b/apps/dashboard/services/lease/LocalLeaseService.ts
@@ -1,5 +1,5 @@
-import {LeaseModel} from './LeaseModel';
-import {LeaseService} from './LeaseService';
+import type {LeaseModel} from './LeaseModel';
+import type {LeaseService} from './LeaseService';
 
 export class LocalLeaseService implements LeaseService {
   private readonly byUnitId = new Map<string, LeaseModel>(

--- a/apps/dashboard/services/property/LocalPropertyService.ts
+++ b/apps/dashboard/services/property/LocalPropertyService.ts
@@ -1,6 +1,6 @@
 import {nanoid} from 'nanoid';
-import {NewPropertyData, PropertyModel} from './PropertyModel';
-import {PropertyNotFoundErr, PropertyService} from './PropertyService';
+import type {NewPropertyData, PropertyModel} from './PropertyModel';
+import {PropertyNotFoundErr, type PropertyService} from './PropertyService';
 
 export class LocalPropertyService implements PropertyService {
   private readonly properties: Map<string, PropertyModel> = new Map(

--- a/apps/dashboard/services/property/PropertyModel.ts
+++ b/apps/dashboard/services/property/PropertyModel.ts
@@ -1,4 +1,4 @@
-import {AddressModel} from '@/services/address';
+import type {AddressModel} from '@/services/address';
 
 export type PropertyType = 'single-family' | 'multi-family';
 export type PropertyModel = SingleFamily.Property | MultiFamily.Property;

--- a/apps/dashboard/services/property/PropertyService.ts
+++ b/apps/dashboard/services/property/PropertyService.ts
@@ -1,4 +1,4 @@
-import {NewPropertyData, PropertyModel} from './PropertyModel';
+import type {NewPropertyData, PropertyModel} from './PropertyModel';
 
 export interface PropertyService {
   getAll(): Promise<PropertyModel[]>;

--- a/apps/dashboard/services/property/PropertyServiceContext.tsx
+++ b/apps/dashboard/services/property/PropertyServiceContext.tsx
@@ -1,5 +1,5 @@
-import {createContext, PropsWithChildren, useContext} from 'react';
-import {PropertyService} from './PropertyService';
+import {createContext, useContext, type PropsWithChildren} from 'react';
+import type {PropertyService} from './PropertyService';
 
 export function PropertyServiceProvider({
   service,

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
@@ -16,12 +17,18 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "verbatimModuleSyntax": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/apps/dashboard/volto/AspectRatio.tsx
+++ b/apps/dashboard/volto/AspectRatio.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {ElementType, PropsWithChildren, ReactNode} from 'react';
+import type {ElementType, PropsWithChildren, ReactNode} from 'react';
 import * as s from './AspectRatio.css';
 
 type AspectRatioProps = PropsWithChildren<{

--- a/apps/dashboard/volto/Badge.tsx
+++ b/apps/dashboard/volto/Badge.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as s from './Badge.css';
 
 type BadgeProps = {

--- a/apps/dashboard/volto/Button/Button.tsx
+++ b/apps/dashboard/volto/Button/Button.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {
+import type {
   ComponentPropsWithoutRef,
   ElementType,
   PropsWithChildren,

--- a/apps/dashboard/volto/ButtonGroup.tsx
+++ b/apps/dashboard/volto/ButtonGroup.tsx
@@ -1,5 +1,5 @@
 import {Button} from '@/volto/Button';
-import {ComponentPropsWithoutRef, ReactElement} from 'react';
+import type {ComponentPropsWithoutRef, ReactElement} from 'react';
 import * as s from './ButtonGroup.css';
 
 type ButtonGroupProps = {

--- a/apps/dashboard/volto/Card.tsx
+++ b/apps/dashboard/volto/Card.tsx
@@ -1,4 +1,4 @@
-import {ElementType, PropsWithChildren, ReactNode} from 'react';
+import type {ElementType, PropsWithChildren, ReactNode} from 'react';
 import * as s from './Card.css';
 
 type CardProps = PropsWithChildren<{

--- a/apps/dashboard/volto/EmptyState.tsx
+++ b/apps/dashboard/volto/EmptyState.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, ReactNode} from 'react';
+import type {ReactElement, ReactNode} from 'react';
 import * as s from './EmptyState.css';
 
 type EmptyStateProps = {

--- a/apps/dashboard/volto/NumericField.tsx
+++ b/apps/dashboard/volto/NumericField.tsx
@@ -1,4 +1,4 @@
-import {ComponentPropsWithoutRef} from 'react';
+import type {ComponentPropsWithoutRef} from 'react';
 import {TextField} from './TextField';
 
 type NumericFieldProps = {

--- a/apps/dashboard/volto/Radio/Radio.tsx
+++ b/apps/dashboard/volto/Radio/Radio.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {ComponentPropsWithRef, forwardRef} from 'react';
+import {forwardRef, type ComponentPropsWithRef} from 'react';
 import * as s from './Radio.css';
 
 type RadioProps = ComponentPropsWithRef<'input'>;

--- a/apps/dashboard/volto/Radio/useRadio.ts
+++ b/apps/dashboard/volto/Radio/useRadio.ts
@@ -1,5 +1,5 @@
-import {ChangeEvent, RefObject} from 'react';
-import {RadioGroupState} from './useRadioGroupState';
+import type {ChangeEvent, RefObject} from 'react';
+import type {RadioGroupState} from './useRadioGroupState';
 
 type RadioProps<T> = {
   name: string;

--- a/apps/dashboard/volto/Section.tsx
+++ b/apps/dashboard/volto/Section.tsx
@@ -1,5 +1,5 @@
 import {Card} from '@/volto/Card';
-import {CSSProperties, PropsWithChildren, ReactNode} from 'react';
+import type {CSSProperties, PropsWithChildren, ReactNode} from 'react';
 import * as s from './Section.css';
 import {Skeleton} from './Skeleton';
 

--- a/apps/dashboard/volto/Select.tsx
+++ b/apps/dashboard/volto/Select.tsx
@@ -1,6 +1,6 @@
 import {ExpandMoreIcon} from '@/volto/icons';
 import clsx from 'clsx';
-import {SelectHTMLAttributes, useId} from 'react';
+import {useId, type SelectHTMLAttributes} from 'react';
 import * as s from './Select.css';
 
 type Option = {

--- a/apps/dashboard/volto/Skeleton/Skeleton.tsx
+++ b/apps/dashboard/volto/Skeleton/Skeleton.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {CSSProperties} from 'react';
+import type {CSSProperties} from 'react';
 import * as s from './Skeleton.css';
 
 type SkeletonProps = {

--- a/apps/dashboard/volto/Stack.tsx
+++ b/apps/dashboard/volto/Stack.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {ElementType, PropsWithChildren} from 'react';
+import type {ElementType, PropsWithChildren} from 'react';
 import * as s from './Stack.css';
 
 type StackProps = PropsWithChildren<{

--- a/apps/dashboard/volto/TextField.tsx
+++ b/apps/dashboard/volto/TextField.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import {InputHTMLAttributes, useId} from 'react';
+import {useId, type InputHTMLAttributes} from 'react';
 import * as s from './TextField.css';
 
 type OwnTextFieldProps = {

--- a/apps/dashboard/volto/Tooltip/CopyToClipboardTooltip.tsx
+++ b/apps/dashboard/volto/Tooltip/CopyToClipboardTooltip.tsx
@@ -7,8 +7,8 @@ import {Card} from '@/volto/Card';
 import {CheckIcon} from '@/volto/icons';
 import {useEffect, useState} from 'react';
 import * as s from './CopyToClipboardTooltip.css';
-import {Tooltip, TooltipProps} from './Tooltip';
-import {TooltipState} from './useTooltipState';
+import {Tooltip, type TooltipProps} from './Tooltip';
+import type {TooltipState} from './useTooltipState';
 
 type CopyToClipboardTooltipProps = {
   isCopied: boolean;

--- a/apps/dashboard/volto/Tooltip/Tooltip.tsx
+++ b/apps/dashboard/volto/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
-import {AriaPositionProps, useOverlayPosition} from '@react-aria/overlays';
-import {PropsWithChildren, useEffect, useRef} from 'react';
+import {useOverlayPosition, type AriaPositionProps} from '@react-aria/overlays';
+import {useEffect, useRef, type PropsWithChildren} from 'react';
 import {createPortal} from 'react-dom';
 import * as s from './Tooltip.css';
 import {useTooltipsManager} from './TooltipsManager';

--- a/apps/dashboard/volto/Tooltip/TooltipsManager.tsx
+++ b/apps/dashboard/volto/Tooltip/TooltipsManager.tsx
@@ -1,10 +1,10 @@
 import {
   createContext,
   forwardRef,
-  PropsWithChildren,
   useContext,
   useRef,
   useState,
+  type PropsWithChildren,
 } from 'react';
 import * as s from './TooltipsManager.css';
 
@@ -17,9 +17,7 @@ type TooltipsManager = {
   visibility: VisibilityManager;
 };
 
-type TooltipsManagerProviderProps = PropsWithChildren<{}>;
-
-export function TooltipsManagerProvider(props: TooltipsManagerProviderProps) {
+export function TooltipsManagerProvider(props: PropsWithChildren) {
   const {children} = props;
   // Cannot use useRef here because it does not cause a re-render
   // thus the context is not updated after the container mounted.

--- a/apps/dashboard/volto/Tooltip/useTooltip.ts
+++ b/apps/dashboard/volto/Tooltip/useTooltip.ts
@@ -1,5 +1,5 @@
 import {useId} from 'react';
-import {TooltipState, useTooltipState} from './useTooltipState';
+import {useTooltipState, type TooltipState} from './useTooltipState';
 
 type TriggerProps = {
   'aria-describedby'?: string;

--- a/apps/dashboard/volto/boxShadow.css.ts
+++ b/apps/dashboard/volto/boxShadow.css.ts
@@ -1,4 +1,4 @@
-import {border, BorderWidthKey} from './border.css';
+import {border, type BorderWidthKey} from './border.css';
 
 export const boxShadow = {
   asBorder,

--- a/apps/dashboard/volto/icons/SvgIcon.tsx
+++ b/apps/dashboard/volto/icons/SvgIcon.tsx
@@ -1,6 +1,6 @@
-import {PropsWithChildren} from 'react';
+import type {PropsWithChildren} from 'react';
 
-export function SvgIcon({children}: PropsWithChildren<{}>) {
+export function SvgIcon({children}: PropsWithChildren) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Update `tsconfig.json` based on an example app generated with `create-next-app@13.5.3`.

The majority of the changes are due to enabling [`verbatimModuleSyntax` option](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) in `tsconfig`, which is available after TS v5.